### PR TITLE
fix(model): guard extra_body type assertion in openai model

### DIFF
--- a/model/openai.go
+++ b/model/openai.go
@@ -93,7 +93,9 @@ func (m *openAIModel) GenerateContent(ctx context.Context, req *model.LLMRequest
 		}
 	}
 	if extraBody, ok := m.config.ExtraBody["extra_body"]; ok {
-		openaiReq.ExtraBody = extraBody.(map[string]any)
+		if eb, ok := extraBody.(map[string]any); ok {
+			openaiReq.ExtraBody = eb
+		}
 	}
 
 	if stream {

--- a/model/openai_test.go
+++ b/model/openai_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/adk/model"
 	"google.golang.org/genai"
 )
@@ -172,6 +173,45 @@ func newTestModel(t *testing.T, server *httptest.Server) model.LLM {
 		t.Fatalf("failed to create model: %v", err)
 	}
 	return llm
+}
+
+func TestOpenAIModel_GenerateContentSkipsInvalidExtraBody(t *testing.T) {
+	tests := []struct {
+		name      string
+		extraBody any
+	}{
+		{
+			name:      "string",
+			extraBody: "not-a-map",
+		},
+		{
+			name: "map_string_string",
+			extraBody: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	req := &model.LLMRequest{
+		Contents: genai.Text("hello"),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			llm, err := NewOpenAIModel(context.Background(), "test-model", &ClientConfig{
+				APIKey:  "dummy-api-key",
+				BaseURL: "http://example.com",
+				ExtraBody: map[string]any{
+					"extra_body": tt.extraBody,
+				},
+			})
+			require.NoError(t, err)
+
+			require.NotPanics(t, func() {
+				_ = llm.GenerateContent(t.Context(), req, false)
+			})
+		})
+	}
 }
 
 func TestModel_Generate(t *testing.T) {


### PR DESCRIPTION
## Summary
- Guard OpenAI-compatible extra_body handling with a safe type assertion.
- Silently skip invalid extra_body values instead of panicking before iterator creation.
- Add regression coverage for string and map[string]string extra_body values.

## Tests
- `go build -mod=readonly -v ./...` (passed)
- `go test -mod=readonly -v -race ./model/...` (passed)
- `golangci-lint run --timeout=10m` (fails on 15 pre-existing upstream/main issues outside this PR)
- `golangci-lint run --timeout=10m --new-from-rev=upstream/main` (passed, 0 issues)