### PR TITLE
feat(examples): add image edit and link reader examples

### DIFF
--- a/examples/tool/image_edit/agent_with_image_edit_tool.go
+++ b/examples/tool/image_edit/agent_with_image_edit_tool.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+
+	veagent "github.com/volcengine/veadk-go/agent/llmagent"
+	"github.com/volcengine/veadk-go/apps"
+	"github.com/volcengine/veadk-go/apps/agentkit_server_app"
+	"github.com/volcengine/veadk-go/log"
+	"github.com/volcengine/veadk-go/tool/builtin_tools"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/tool"
+)
+
+func main() {
+	ctx := context.Background()
+
+	imageEdit, err := builtin_tools.NewImageEditTool(&builtin_tools.ImageEditConfig{})
+	if err != nil {
+		log.Errorf("NewImageEditTool failed: %v", err)
+		return
+	}
+
+	rootAgent, err := veagent.New(&veagent.Config{
+		Config: llmagent.Config{
+			Name:        "image_edit_tool_agent",
+			Description: "Agent to edit images based on prompts and source images.",
+			Instruction: "I can edit images based on prompts and source images.",
+			Tools:       []tool.Tool{imageEdit},
+		},
+	})
+
+	if err != nil {
+		log.Error("Failed to create agent: %v", err)
+		return
+	}
+
+	app := agentkit_server_app.NewAgentkitServerApp(apps.DefaultApiConfig())
+
+	err = app.Run(ctx, &apps.RunConfig{
+		AgentLoader: agent.NewSingleLoader(rootAgent),
+	})
+	if err != nil {
+		log.Errorf("Run failed: %v", err)
+	}
+}

--- a/examples/tool/link_reader/agent_with_link_reader_tool.go
+++ b/examples/tool/link_reader/agent_with_link_reader_tool.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+
+	veagent "github.com/volcengine/veadk-go/agent/llmagent"
+	"github.com/volcengine/veadk-go/apps"
+	"github.com/volcengine/veadk-go/apps/agentkit_server_app"
+	"github.com/volcengine/veadk-go/log"
+	"github.com/volcengine/veadk-go/tool/builtin_tools"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/tool"
+)
+
+func main() {
+	ctx := context.Background()
+
+	linkReader, err := builtin_tools.NewLinkReaderTool(&builtin_tools.LinkReaderConfig{})
+	if err != nil {
+		log.Errorf("NewLinkReaderTool failed: %v", err)
+		return
+	}
+
+	rootAgent, err := veagent.New(&veagent.Config{
+		Config: llmagent.Config{
+			Name:        "link_reader_tool_agent",
+			Description: "Agent to read links and extract main content.",
+			Instruction: "I can read links and extract titles and main content from web pages, PDFs, or Douyin videos.",
+			Tools:       []tool.Tool{linkReader},
+		},
+	})
+
+	if err != nil {
+		log.Error("Failed to create agent: %v", err)
+		return
+	}
+
+	app := agentkit_server_app.NewAgentkitServerApp(apps.DefaultApiConfig())
+
+	err = app.Run(ctx, &apps.RunConfig{
+		AgentLoader: agent.NewSingleLoader(rootAgent),
+	})
+	if err != nil {
+		log.Errorf("Run failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add an image edit tool example using `NewImageEditTool`.
- Add a link reader tool example using `NewLinkReaderTool`.
- Mirror the existing AgentKit server app example structure and Apache license header.

## Tests
- `go build -mod=readonly -v ./...` (passed; built `examples/tool/image_edit` and `examples/tool/link_reader`)
- `go vet ./examples/...` (passed)
- `golangci-lint run --timeout=10m` (passed with golangci-lint v1.64.8)