### PR TITLE
feat(knowledgebase): add opensearch backend

### DIFF
--- a/knowledgebase/backend/opensearch_knowledge_backend/opensearch_knowledge_backend.go
+++ b/knowledgebase/backend/opensearch_knowledge_backend/opensearch_knowledge_backend.go
@@ -1,0 +1,498 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensearch_knowledge_backend
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/volcengine/veadk-go/configs"
+	_interface "github.com/volcengine/veadk-go/knowledgebase/interface"
+	"github.com/volcengine/veadk-go/knowledgebase/ktypes"
+	"github.com/volcengine/veadk-go/log"
+	"github.com/volcengine/veadk-go/model"
+)
+
+const (
+	DefaultOpenSearchIndex = "veadk_knowledge"
+	DefaultOpenSearchPort  = 9200
+	DefaultTopK            = 5
+)
+
+var (
+	ErrOpenSearchKnowledgeBackend = errors.New("opensearch knowledge backend error")
+	ErrInvalidEmbedding           = errors.New("invalid embedding response")
+	ErrInvalidIndexName           = errors.New("invalid OpenSearch index name")
+	indexNameRegexp               = regexp.MustCompile(`^[a-z0-9][a-z0-9_\-.]*$`)
+)
+
+type Config struct {
+	Host     string
+	Port     int
+	Username string
+	Password string
+	UseSSL   bool
+	CertPath string
+	Index    string
+	TopK     int
+
+	EmbeddingModel   string
+	EmbeddingAPIKey  string
+	EmbeddingBaseURL string
+	EmbeddingDim     int
+}
+
+type OpenSearchKnowledgeBackend struct {
+	config     *Config
+	httpClient *http.Client
+	baseURL    string
+	embedder   model.Embedder
+}
+
+func NewOpenSearchKnowledgeBackend(cfg *Config) (_interface.KnowledgeBackend, error) {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	if cfg.Port == 0 {
+		cfg.Port = DefaultOpenSearchPort
+	}
+	if cfg.Index == "" {
+		cfg.Index = DefaultOpenSearchIndex
+	}
+	if cfg.TopK <= 0 {
+		cfg.TopK = DefaultTopK
+	}
+	if err := validateIndexName(cfg.Index); err != nil {
+		return nil, err
+	}
+	applyEmbeddingDefaults(cfg)
+
+	embedder, err := model.NewArkEmbeddingModel(context.Background(), cfg.EmbeddingModel, &model.ArkEmbeddingConfig{
+		APIKey:     cfg.EmbeddingAPIKey,
+		BaseURL:    cfg.EmbeddingBaseURL,
+		Dimensions: cfg.EmbeddingDim,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: create embedder: %w", ErrOpenSearchKnowledgeBackend, err)
+	}
+
+	httpClient, err := buildHTTPClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	scheme := "http"
+	if cfg.UseSSL {
+		scheme = "https"
+	}
+	baseURL := fmt.Sprintf("%s://%s:%d", scheme, cfg.Host, cfg.Port)
+
+	return &OpenSearchKnowledgeBackend{
+		config:     cfg,
+		httpClient: httpClient,
+		baseURL:    baseURL,
+		embedder:   embedder,
+	}, nil
+}
+
+func (o *OpenSearchKnowledgeBackend) Index() string {
+	return o.config.Index
+}
+
+func (o *OpenSearchKnowledgeBackend) AddFromText(text []string, opts ...map[string]any) error {
+	contents := make([]string, 0, len(text))
+	metadatas := make([][]map[string]any, 0, len(text))
+	for _, t := range text {
+		if strings.TrimSpace(t) == "" {
+			continue
+		}
+		contents = append(contents, t)
+		metadatas = append(metadatas, metadataWithSource("text", "", opts...))
+	}
+	return o.addEntries(context.Background(), contents, metadatas)
+}
+
+func (o *OpenSearchKnowledgeBackend) AddFromFiles(files []string, opts ...map[string]any) error {
+	contents := make([]string, 0, len(files))
+	metadatas := make([][]map[string]any, 0, len(files))
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return fmt.Errorf("%w: read file %q: %w", ErrOpenSearchKnowledgeBackend, file, err)
+		}
+		if strings.TrimSpace(string(data)) == "" {
+			continue
+		}
+		contents = append(contents, string(data))
+		metadatas = append(metadatas, metadataWithSource("file", file, opts...))
+	}
+	return o.addEntries(context.Background(), contents, metadatas)
+}
+
+func (o *OpenSearchKnowledgeBackend) AddFromDirectory(directory string, opts ...map[string]any) error {
+	info, err := os.Stat(directory)
+	if err != nil {
+		return fmt.Errorf("%w: stat directory %q: %w", ErrOpenSearchKnowledgeBackend, directory, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%w: %q is not a directory", ErrOpenSearchKnowledgeBackend, directory)
+	}
+
+	files := make([]string, 0)
+	err = filepath.WalkDir(directory, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.Type().IsRegular() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("%w: walk directory %q: %w", ErrOpenSearchKnowledgeBackend, directory, err)
+	}
+	sort.Strings(files)
+	return o.AddFromFiles(files, opts...)
+}
+
+func (o *OpenSearchKnowledgeBackend) Search(query string, opts ...map[string]any) ([]ktypes.KnowledgeEntry, error) {
+	if strings.TrimSpace(query) == "" {
+		return []ktypes.KnowledgeEntry{}, nil
+	}
+
+	topK := extractIntOpt("topK", o.config.TopK, opts...)
+	topK = extractIntOpt("top_k", topK, opts...)
+	if topK <= 0 {
+		topK = o.config.TopK
+	}
+
+	if err := validateIndexName(o.config.Index); err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	resp, err := o.embedder.EmbedTexts(ctx, &model.EmbeddingRequest{Texts: []string{query}})
+	if err != nil {
+		return nil, fmt.Errorf("%w: embed query: %w", ErrOpenSearchKnowledgeBackend, err)
+	}
+	if len(resp.Embeddings) != 1 {
+		return nil, fmt.Errorf("%w: got invalid query embedding response", ErrInvalidEmbedding)
+	}
+
+	searchBody := map[string]any{
+		"size": topK,
+		"query": map[string]any{
+			"knn": map[string]any{
+				"vector": map[string]any{
+					"vector": resp.Embeddings[0],
+					"k":      topK,
+				},
+			},
+		},
+		"_source": []string{"text", "metadata"},
+	}
+
+	body, _ := json.Marshal(searchBody)
+	searchResp, err := o.doRequest(ctx, http.MethodPost, "/"+o.config.Index+"/_search", body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: search opensearch: %w", ErrOpenSearchKnowledgeBackend, err)
+	}
+	defer searchResp.Body.Close()
+
+	respBody, err := io.ReadAll(searchResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: read opensearch response: %w", ErrOpenSearchKnowledgeBackend, err)
+	}
+	if searchResp.StatusCode != http.StatusOK {
+		if strings.Contains(string(respBody), "index_not_found_exception") {
+			return []ktypes.KnowledgeEntry{}, nil
+		}
+		return nil, fmt.Errorf("%w: search failed: status=%d, body=%s", ErrOpenSearchKnowledgeBackend, searchResp.StatusCode, string(respBody))
+	}
+
+	return parseOpenSearchResults(respBody)
+}
+
+func (o *OpenSearchKnowledgeBackend) addEntries(ctx context.Context, contents []string, metadatas [][]map[string]any) error {
+	if len(contents) == 0 {
+		return nil
+	}
+	if err := validateIndexName(o.config.Index); err != nil {
+		return err
+	}
+	if err := o.ensureIndex(ctx); err != nil {
+		return err
+	}
+
+	resp, err := o.embedder.EmbedTexts(ctx, &model.EmbeddingRequest{Texts: contents})
+	if err != nil {
+		return fmt.Errorf("%w: embed documents: %w", ErrOpenSearchKnowledgeBackend, err)
+	}
+	if len(resp.Embeddings) != len(contents) {
+		return fmt.Errorf("%w: got %d embeddings for %d documents", ErrInvalidEmbedding, len(resp.Embeddings), len(contents))
+	}
+
+	var buf bytes.Buffer
+	for i, content := range contents {
+		action := map[string]any{
+			"index": map[string]any{
+				"_index": o.config.Index,
+			},
+		}
+		doc := map[string]any{
+			"text":     content,
+			"metadata": cloneMetadata(metadatas[i]),
+			"vector":   resp.Embeddings[i],
+		}
+
+		actionLine, _ := json.Marshal(action)
+		docLine, _ := json.Marshal(doc)
+		buf.Write(actionLine)
+		buf.WriteByte('\n')
+		buf.Write(docLine)
+		buf.WriteByte('\n')
+	}
+
+	bulkResp, err := o.doRequest(ctx, http.MethodPost, "/_bulk", buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("%w: bulk index to opensearch: %w", ErrOpenSearchKnowledgeBackend, err)
+	}
+	defer bulkResp.Body.Close()
+
+	if bulkResp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(bulkResp.Body)
+		return fmt.Errorf("%w: bulk index failed: status=%d, body=%s", ErrOpenSearchKnowledgeBackend, bulkResp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+func (o *OpenSearchKnowledgeBackend) ensureIndex(ctx context.Context) error {
+	mapping := map[string]any{
+		"settings": map[string]any{
+			"index": map[string]any{
+				"knn": true,
+			},
+		},
+		"mappings": map[string]any{
+			"properties": map[string]any{
+				"text": map[string]any{
+					"type": "text",
+				},
+				"metadata": map[string]any{
+					"type": "object",
+				},
+				"vector": map[string]any{
+					"type":      "knn_vector",
+					"dimension": o.config.EmbeddingDim,
+					"method": map[string]any{
+						"name":       "hnsw",
+						"space_type": "cosinesimil",
+						"engine":     "nmslib",
+					},
+				},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(mapping)
+	resp, err := o.doRequest(ctx, http.MethodPut, "/"+o.config.Index, body)
+	if err != nil {
+		return fmt.Errorf("%w: create index %q: %w", ErrOpenSearchKnowledgeBackend, o.config.Index, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
+		log.Infof("Created OpenSearch knowledge index %q with dimension %d", o.config.Index, o.config.EmbeddingDim)
+		return nil
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(respBody), "resource_already_exists_exception") {
+		return nil
+	}
+
+	return fmt.Errorf("%w: create index %q failed: status=%d, body=%s", ErrOpenSearchKnowledgeBackend, o.config.Index, resp.StatusCode, string(respBody))
+}
+
+func parseOpenSearchResults(respBody []byte) ([]ktypes.KnowledgeEntry, error) {
+	var result struct {
+		Hits struct {
+			Hits []struct {
+				Source struct {
+					Text     string           `json:"text"`
+					Metadata []map[string]any `json:"metadata"`
+				} `json:"_source"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}
+
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("%w: parse opensearch response: %w", ErrOpenSearchKnowledgeBackend, err)
+	}
+
+	entries := make([]ktypes.KnowledgeEntry, 0, len(result.Hits.Hits))
+	for _, hit := range result.Hits.Hits {
+		if hit.Source.Text == "" {
+			continue
+		}
+		entries = append(entries, ktypes.KnowledgeEntry{
+			Content:  hit.Source.Text,
+			Metadata: cloneMetadata(hit.Source.Metadata),
+		})
+	}
+	return entries, nil
+}
+
+func buildHTTPClient(config *Config) (*http.Client, error) {
+	transport := &http.Transport{}
+
+	if config.UseSSL {
+		tlsCfg := &tls.Config{} //nolint:gosec // user can configure cert verification
+		if config.CertPath != "" {
+			caCert, err := os.ReadFile(config.CertPath)
+			if err != nil {
+				return nil, fmt.Errorf("%w: read cert file %q: %w", ErrOpenSearchKnowledgeBackend, config.CertPath, err)
+			}
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM(caCert) {
+				return nil, fmt.Errorf("%w: parse cert file %q", ErrOpenSearchKnowledgeBackend, config.CertPath)
+			}
+			tlsCfg.RootCAs = pool
+		} else {
+			log.Warn("OpenSearch cert_path is not set, which may lead to security risks")
+			tlsCfg.InsecureSkipVerify = true //nolint:gosec // user chose not to provide cert
+		}
+		transport.TLSClientConfig = tlsCfg
+	}
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second,
+	}, nil
+}
+
+func validateIndexName(name string) error {
+	if !indexNameRegexp.MatchString(name) {
+		return fmt.Errorf("%w: %q (must be lowercase, start with alphanumeric, contain only [a-z0-9_\\-.])", ErrInvalidIndexName, name)
+	}
+	return nil
+}
+
+func (o *OpenSearchKnowledgeBackend) doRequest(ctx context.Context, method, path string, body []byte) (*http.Response, error) {
+	url := o.baseURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if o.config.Username != "" || o.config.Password != "" {
+		req.SetBasicAuth(o.config.Username, o.config.Password)
+	}
+
+	return o.httpClient.Do(req)
+}
+
+func applyEmbeddingDefaults(cfg *Config) {
+	global := configs.GetGlobalConfig()
+	if cfg.EmbeddingModel == "" {
+		cfg.EmbeddingModel = global.Model.Embedding.Name
+	}
+	if cfg.EmbeddingAPIKey == "" {
+		cfg.EmbeddingAPIKey = global.Model.Embedding.ApiKey
+	}
+	if cfg.EmbeddingBaseURL == "" {
+		cfg.EmbeddingBaseURL = global.Model.Embedding.ApiBase
+	}
+	if cfg.EmbeddingDim == 0 {
+		cfg.EmbeddingDim = global.Model.Embedding.Dim
+	}
+}
+
+func metadataWithSource(source, filePath string, opts ...map[string]any) []map[string]any {
+	metadata := extractMetadata(opts...)
+	sourceMetadata := map[string]any{"source": source}
+	if filePath != "" {
+		sourceMetadata["file_path"] = filePath
+	}
+	return append(metadata, sourceMetadata)
+}
+
+func extractMetadata(opts ...map[string]any) []map[string]any {
+	for _, opt := range opts {
+		val, ok := opt["metadata"]
+		if !ok {
+			continue
+		}
+		switch metadata := val.(type) {
+		case map[string]any:
+			return []map[string]any{cloneMap(metadata)}
+		case []map[string]any:
+			return cloneMetadata(metadata)
+		}
+	}
+	return nil
+}
+
+func extractIntOpt(key string, defaultVal int, opts ...map[string]any) int {
+	for _, opt := range opts {
+		if val, ok := opt[key]; ok {
+			if intVal, ok := val.(int); ok {
+				return intVal
+			}
+		}
+	}
+	return defaultVal
+}
+
+func cloneMetadata(metadata []map[string]any) []map[string]any {
+	if len(metadata) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(metadata))
+	for _, item := range metadata {
+		out = append(out, cloneMap(item))
+	}
+	return out
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/knowledgebase/backend/opensearch_knowledge_backend/opensearch_knowledge_backend_test.go
+++ b/knowledgebase/backend/opensearch_knowledge_backend/opensearch_knowledge_backend_test.go
@@ -1,0 +1,408 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opensearch_knowledge_backend
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
+	"github.com/volcengine/veadk-go/model"
+)
+
+func TestOpenSearchKnowledgeBackend_New(t *testing.T) {
+	mockey.PatchConvey("TestOpenSearchKnowledgeBackend_New", t, func() {
+		mockey.PatchConvey("embedder creation failed", func() {
+			mockey.Mock(model.NewArkEmbeddingModel).Return(nil, errors.New("embedder error")).Build()
+			backend, err := NewOpenSearchKnowledgeBackend(&Config{Host: "localhost"})
+			assert.Nil(t, backend)
+			assert.NotNil(t, err)
+			assert.Contains(t, err.Error(), "create embedder")
+		})
+
+		mockey.PatchConvey("defaults applied", func() {
+			cfg := &Config{Host: "localhost"}
+			mockey.Mock(model.NewArkEmbeddingModel).Return(nil, errors.New("stop")).Build()
+			_, _ = NewOpenSearchKnowledgeBackend(cfg)
+
+			assert.Equal(t, DefaultOpenSearchPort, cfg.Port)
+			assert.Equal(t, DefaultOpenSearchIndex, cfg.Index)
+			assert.Equal(t, DefaultTopK, cfg.TopK)
+			assert.NotZero(t, cfg.EmbeddingDim)
+		})
+
+		mockey.PatchConvey("success with ssl", func() {
+			mockey.Mock(model.NewArkEmbeddingModel).Return(&mockOpenSearchEmbedder{}, nil).Build()
+			backend, err := NewOpenSearchKnowledgeBackend(&Config{
+				Host:             "localhost",
+				UseSSL:           true,
+				EmbeddingModel:   "embedding",
+				EmbeddingAPIKey:  "key",
+				EmbeddingBaseURL: "https://ark.example",
+				EmbeddingDim:     3,
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, backend)
+
+			osBackend := backend.(*OpenSearchKnowledgeBackend)
+			assert.Equal(t, "https://localhost:9200", osBackend.baseURL)
+		})
+
+		mockey.PatchConvey("success without ssl", func() {
+			mockey.Mock(model.NewArkEmbeddingModel).Return(&mockOpenSearchEmbedder{}, nil).Build()
+			backend, err := NewOpenSearchKnowledgeBackend(&Config{
+				Host:            "localhost",
+				Port:            9201,
+				EmbeddingModel:  "embedding",
+				EmbeddingAPIKey: "key",
+				EmbeddingDim:    3,
+			})
+			assert.Nil(t, err)
+			assert.NotNil(t, backend)
+
+			osBackend := backend.(*OpenSearchKnowledgeBackend)
+			assert.Equal(t, "http://localhost:9201", osBackend.baseURL)
+		})
+
+		mockey.PatchConvey("invalid index name", func() {
+			backend, err := NewOpenSearchKnowledgeBackend(&Config{
+				Host:            "localhost",
+				Index:           "Invalid",
+				EmbeddingAPIKey: "key",
+				EmbeddingDim:    3,
+			})
+			assert.Nil(t, backend)
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, ErrInvalidIndexName)
+		})
+	})
+}
+
+func TestOpenSearchKnowledgeBackend_ValidateIndexName(t *testing.T) {
+	tests := []struct {
+		name    string
+		index   string
+		wantErr bool
+	}{
+		{"valid lowercase", "veadk_knowledge", false},
+		{"valid with dash", "veadk-knowledge", false},
+		{"valid with dot", "veadk.knowledge", false},
+		{"starts with underscore", "_invalid", true},
+		{"starts with dash", "-invalid", true},
+		{"uppercase", "INVALID", true},
+		{"empty", "", true},
+		{"special chars", "invalid@name", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateIndexName(tt.index)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+				assert.ErrorIs(t, err, ErrInvalidIndexName)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestOpenSearchKnowledgeBackend_AddFromText(t *testing.T) {
+	mockey.PatchConvey("TestOpenSearchKnowledgeBackend_AddFromText", t, func() {
+		backend := newTestOpenSearchBackend()
+		callCount := 0
+		var bulkBody []byte
+		mockey.Mock((*OpenSearchKnowledgeBackend).doRequest).To(func(ctx context.Context, method, path string, body []byte) (*http.Response, error) {
+			_ = ctx
+			callCount++
+			if callCount == 1 {
+				assert.Equal(t, http.MethodPut, method)
+				assert.Equal(t, "/test_knowledge", path)
+			} else {
+				assert.Equal(t, http.MethodPost, method)
+				assert.Equal(t, "/_bulk", path)
+				bulkBody = append([]byte(nil), body...)
+			}
+			return okResponse(`{"acknowledged":true}`), nil
+		}).Build()
+
+		err := backend.AddFromText([]string{"agent knowledge", "   "}, map[string]any{"metadata": map[string]any{"tenant": "test"}})
+		assert.Nil(t, err)
+		assert.Equal(t, 2, callCount)
+		assert.Contains(t, string(bulkBody), `"text":"agent knowledge"`)
+		assert.Contains(t, string(bulkBody), `"tenant":"test"`)
+		assert.Contains(t, string(bulkBody), `"source":"text"`)
+	})
+}
+
+func TestOpenSearchKnowledgeBackend_AddFromFiles(t *testing.T) {
+	mockey.PatchConvey("TestOpenSearchKnowledgeBackend_AddFromFiles", t, func() {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "agent.txt")
+		err := os.WriteFile(file, []byte("file knowledge"), 0600)
+		assert.Nil(t, err)
+
+		backend := newTestOpenSearchBackend()
+		var bulkBody []byte
+		mockey.Mock((*OpenSearchKnowledgeBackend).doRequest).To(func(ctx context.Context, method, path string, body []byte) (*http.Response, error) {
+			_ = ctx
+			if path == "/_bulk" {
+				bulkBody = append([]byte(nil), body...)
+			}
+			return okResponse(`{"acknowledged":true}`), nil
+		}).Build()
+
+		err = backend.AddFromFiles([]string{file})
+		assert.Nil(t, err)
+		assert.Contains(t, string(bulkBody), `"text":"file knowledge"`)
+		assert.Contains(t, string(bulkBody), `"source":"file"`)
+		assert.Contains(t, string(bulkBody), `"file_path":"`+file+`"`)
+	})
+}
+
+func TestOpenSearchKnowledgeBackend_AddFromDirectory(t *testing.T) {
+	mockey.PatchConvey("TestOpenSearchKnowledgeBackend_AddFromDirectory", t, func() {
+		dir := t.TempDir()
+		err := os.WriteFile(filepath.Join(dir, "alpha.txt"), []byte("alpha knowledge"), 0600)
+		assert.Nil(t, err)
+		nested := filepath.Join(dir, "nested")
+		err = os.Mkdir(nested, 0700)
+		assert.Nil(t, err)
+		err = os.WriteFile(filepath.Join(nested, "beta.txt"), []byte("beta knowledge"), 0600)
+		assert.Nil(t, err)
+
+		backend := newTestOpenSearchBackend()
+		var bulkBody []byte
+		mockey.Mock((*OpenSearchKnowledgeBackend).doRequest).To(func(ctx context.Context, method, path string, body []byte) (*http.Response, error) {
+			_ = ctx
+			if path == "/_bulk" {
+				bulkBody = append([]byte(nil), body...)
+			}
+			return okResponse(`{"acknowledged":true}`), nil
+		}).Build()
+
+		err = backend.AddFromDirectory(dir)
+		assert.Nil(t, err)
+		assert.Contains(t, string(bulkBody), `"text":"alpha knowledge"`)
+		assert.Contains(t, string(bulkBody), `"text":"beta knowledge"`)
+	})
+}
+
+func TestOpenSearchKnowledgeBackend_Search(t *testing.T) {
+	mockey.PatchConvey("TestOpenSearchKnowledgeBackend_Search", t, func() {
+		backend := newTestOpenSearchBackend()
+		var searchBody map[string]any
+		responseBody := `{
+			"hits": {
+				"hits": [
+					{"_source": {"text": "knowledge 1", "metadata": [{"tenant": "test"}, {"source": "text"}]}},
+					{"_source": {"text": "knowledge 2", "metadata": [{"source": "file"}]}}
+				]
+			}
+		}`
+		mockey.Mock((*OpenSearchKnowledgeBackend).doRequest).To(func(ctx context.Context, method, path string, body []byte) (*http.Response, error) {
+			_ = ctx
+			assert.Equal(t, http.MethodPost, method)
+			assert.Equal(t, "/test_knowledge/_search", path)
+			err := json.Unmarshal(body, &searchBody)
+			assert.Nil(t, err)
+			return okResponse(responseBody), nil
+		}).Build()
+
+		results, err := backend.Search("agent", map[string]any{"top_k": 2})
+		assert.Nil(t, err)
+		assert.Len(t, results, 2)
+		assert.Equal(t, float64(2), searchBody["size"])
+		assert.Equal(t, "knowledge 1", results[0].Content)
+		assert.Equal(t, "test", results[0].Metadata[0]["tenant"])
+		assert.Equal(t, "knowledge 2", results[1].Content)
+	})
+}
+
+func TestOpenSearchKnowledgeBackend_ErrorPaths(t *testing.T) {
+	mockey.PatchConvey("TestOpenSearchKnowledgeBackend_ErrorPaths", t, func() {
+		mockey.PatchConvey("invalid index", func() {
+			backend := newTestOpenSearchBackend()
+			backend.config.Index = "Invalid"
+			err := backend.AddFromText([]string{"agent"})
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, ErrInvalidIndexName)
+		})
+
+		mockey.PatchConvey("missing file", func() {
+			backend := newTestOpenSearchBackend()
+			err := backend.AddFromFiles([]string{filepath.Join(t.TempDir(), "missing.txt")})
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, ErrOpenSearchKnowledgeBackend)
+		})
+
+		mockey.PatchConvey("directory is file", func() {
+			file := filepath.Join(t.TempDir(), "not-dir.txt")
+			err := os.WriteFile(file, []byte("content"), 0600)
+			assert.Nil(t, err)
+
+			backend := newTestOpenSearchBackend()
+			err = backend.AddFromDirectory(file)
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, ErrOpenSearchKnowledgeBackend)
+		})
+
+		mockey.PatchConvey("ensure index failed", func() {
+			backend := newTestOpenSearchBackend()
+			mockey.Mock((*OpenSearchKnowledgeBackend).doRequest).Return(&http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"boom"}`)),
+			}, nil).Build()
+
+			err := backend.AddFromText([]string{"agent"})
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, ErrOpenSearchKnowledgeBackend)
+		})
+
+		mockey.PatchConvey("embed documents failed", func() {
+			backend := newTestOpenSearchBackend()
+			backend.embedder = &mockOpenSearchEmbedder{err: errors.New("embed error")}
+			mockey.Mock((*OpenSearchKnowledgeBackend).doRequest).Return(okResponse(`{"acknowledged":true}`), nil).Build()
+
+			err := backend.AddFromText([]string{"agent"})
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, ErrOpenSearchKnowledgeBackend)
+		})
+
+		mockey.PatchConvey("invalid embedding response", func() {
+			backend := newTestOpenSearchBackend()
+			backend.embedder = &mockOpenSearchEmbedder{embeddings: map[string][]float32{}}
+			mockey.Mock((*OpenSearchKnowledgeBackend).doRequest).Return(okResponse(`{"acknowledged":true}`), nil).Build()
+
+			err := backend.AddFromText([]string{"agent"})
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, ErrInvalidEmbedding)
+		})
+
+		mockey.PatchConvey("bulk failed", func() {
+			backend := newTestOpenSearchBackend()
+			callCount := 0
+			mockey.Mock((*OpenSearchKnowledgeBackend).doRequest).To(func(ctx context.Context, method, path string, body []byte) (*http.Response, error) {
+				_ = ctx
+				_ = method
+				_ = path
+				_ = body
+				callCount++
+				if callCount == 1 {
+					return okResponse(`{"acknowledged":true}`), nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(`{"error":"bulk"}`)),
+				}, nil
+			}).Build()
+
+			err := backend.AddFromText([]string{"agent"})
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, ErrOpenSearchKnowledgeBackend)
+		})
+
+		mockey.PatchConvey("search index not found", func() {
+			backend := newTestOpenSearchBackend()
+			mockey.Mock((*OpenSearchKnowledgeBackend).doRequest).Return(&http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"index_not_found_exception"}}`)),
+			}, nil).Build()
+
+			results, err := backend.Search("agent")
+			assert.Nil(t, err)
+			assert.Empty(t, results)
+		})
+
+		mockey.PatchConvey("search failed", func() {
+			backend := newTestOpenSearchBackend()
+			mockey.Mock((*OpenSearchKnowledgeBackend).doRequest).Return(&http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"search"}`)),
+			}, nil).Build()
+
+			results, err := backend.Search("agent")
+			assert.Nil(t, results)
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, ErrOpenSearchKnowledgeBackend)
+		})
+
+		mockey.PatchConvey("search parse failed", func() {
+			backend := newTestOpenSearchBackend()
+			mockey.Mock((*OpenSearchKnowledgeBackend).doRequest).Return(okResponse(`invalid`), nil).Build()
+
+			results, err := backend.Search("agent")
+			assert.Nil(t, results)
+			assert.NotNil(t, err)
+			assert.ErrorIs(t, err, ErrOpenSearchKnowledgeBackend)
+		})
+	})
+}
+
+type mockOpenSearchEmbedder struct {
+	embeddings map[string][]float32
+	err        error
+}
+
+func (m *mockOpenSearchEmbedder) EmbedTexts(ctx context.Context, req *model.EmbeddingRequest) (*model.EmbeddingResponse, error) {
+	_ = ctx
+	if m.err != nil {
+		return nil, m.err
+	}
+	embeddings := make([][]float32, 0, len(req.Texts))
+	for i, text := range req.Texts {
+		if m.embeddings != nil {
+			vector, ok := m.embeddings[text]
+			if !ok {
+				continue
+			}
+			embeddings = append(embeddings, vector)
+			continue
+		}
+		embeddings = append(embeddings, []float32{float32(i) + 0.1, 0.2, 0.3})
+	}
+	return &model.EmbeddingResponse{Embeddings: embeddings}, nil
+}
+
+func newTestOpenSearchBackend() *OpenSearchKnowledgeBackend {
+	return &OpenSearchKnowledgeBackend{
+		config: &Config{
+			Host:         "localhost",
+			Port:         DefaultOpenSearchPort,
+			Index:        "test_knowledge",
+			TopK:         DefaultTopK,
+			EmbeddingDim: 3,
+		},
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		baseURL:    "http://localhost:9200",
+		embedder:   &mockOpenSearchEmbedder{},
+	}
+}
+
+func okResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/knowledgebase/knowledgebase.go
+++ b/knowledgebase/knowledgebase.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/volcengine/veadk-go/knowledgebase/backend/local_knowledge_backend"
+	"github.com/volcengine/veadk-go/knowledgebase/backend/opensearch_knowledge_backend"
 	"github.com/volcengine/veadk-go/knowledgebase/backend/viking_knowledge_backend"
 	_interface "github.com/volcengine/veadk-go/knowledgebase/interface"
 	"github.com/volcengine/veadk-go/knowledgebase/ktypes"
@@ -56,7 +57,12 @@ func getKnowledgeBackend(backend string, backendConfig any) (_interface.Knowledg
 			return viking_knowledge_backend.NewVikingKnowledgeBackend(config)
 		}
 		return nil, ErrInvalidKnowledgeBackendConfig
-	case ktypes.RedisBackend, ktypes.OpensearchBackend:
+	case ktypes.OpensearchBackend:
+		if config, ok := backendConfig.(*opensearch_knowledge_backend.Config); ok {
+			return opensearch_knowledge_backend.NewOpenSearchKnowledgeBackend(config)
+		}
+		return nil, ErrInvalidKnowledgeBackendConfig
+	case ktypes.RedisBackend:
 		return nil, fmt.Errorf("%w: %s", ErrInvalidKnowledgeBackend, backend)
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrInvalidKnowledgeBackend, backend)

--- a/knowledgebase/knowledgebase_test.go
+++ b/knowledgebase/knowledgebase_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
 	"github.com/volcengine/veadk-go/knowledgebase/backend/local_knowledge_backend"
+	"github.com/volcengine/veadk-go/knowledgebase/backend/opensearch_knowledge_backend"
 	"github.com/volcengine/veadk-go/knowledgebase/backend/viking_knowledge_backend"
 	_interface "github.com/volcengine/veadk-go/knowledgebase/interface"
 	"github.com/volcengine/veadk-go/knowledgebase/ktypes"
@@ -49,6 +50,22 @@ func TestNewKnowledgeBase_WithStringBackendAndValidConfig(t *testing.T) {
 		kb, err := NewKnowledgeBase(
 			ktypes.VikingBackend,
 			WithBackendConfig(&viking_knowledge_backend.Config{Index: "idx"}),
+			WithName("n"),
+			WithDescription("d"),
+		)
+		assert.Nil(t, err)
+		assert.NotNil(t, kb)
+		assert.Equal(t, "n", kb.Name)
+		assert.Equal(t, "d", kb.Description)
+		assert.Equal(t, m, kb.Backend)
+	})
+	mockey.PatchConvey("opensearch backend with valid config via mock constructor", t, func() {
+		var m _interface.KnowledgeBackend = &mockBackend{}
+		mockey.Mock(opensearch_knowledge_backend.NewOpenSearchKnowledgeBackend).Return(m, nil).Build()
+
+		kb, err := NewKnowledgeBase(
+			ktypes.OpensearchBackend,
+			WithBackendConfig(&opensearch_knowledge_backend.Config{Index: "idx"}),
 			WithName("n"),
 			WithDescription("d"),
 		)
@@ -107,11 +124,19 @@ func TestNewKnowledgeBase_InvalidConfigType(t *testing.T) {
 		assert.Nil(t, kb)
 		assert.True(t, errors.Is(err, ErrInvalidKnowledgeBackendConfig))
 	})
+	mockey.PatchConvey("opensearch backend with invalid config type", t, func() {
+		kb, err := NewKnowledgeBase(
+			ktypes.OpensearchBackend,
+			WithBackendConfig(struct{}{}),
+		)
+		assert.Nil(t, kb)
+		assert.True(t, errors.Is(err, ErrInvalidKnowledgeBackendConfig))
+	})
 }
 
 func TestGetKnowledgeBackend_Unsupported(t *testing.T) {
 	mockey.PatchConvey("unsupported backend types return wrapped error", t, func() {
-		for _, b := range []string{ktypes.RedisBackend, ktypes.OpensearchBackend, "unknown"} {
+		for _, b := range []string{ktypes.RedisBackend, "unknown"} {
 			kb, err := getKnowledgeBackend(b, nil)
 			assert.Nil(t, kb)
 			assert.True(t, errors.Is(err, ErrInvalidKnowledgeBackend))


### PR DESCRIPTION
## Summary
- Add an OpenSearch knowledge backend with index creation, bulk ingestion, vector search, TLS/basic auth support, and metadata round-tripping.
- Wire the opensearch backend constant into knowledgebase backend selection.
- Cover constructor, index validation, text/file/directory ingestion, search, and error paths with mocked OpenSearch responses.

## Tests
- `go build -mod=readonly -v ./...` (passed)
- `go test -mod=readonly -v -race -run OpenSearch ./knowledgebase/...` (passed)
- `go test -mod=readonly ./...` (passed)
- `golangci-lint run --timeout=10m` (passed)
- `go mod tidy -diff` (passed)