### PR TITLE
feat(examples): add vesearch tool example

### DIFF
--- a/examples/tool/vesearch/agent_with_vesearch_tool.go
+++ b/examples/tool/vesearch/agent_with_vesearch_tool.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+
+	veagent "github.com/volcengine/veadk-go/agent/llmagent"
+	"github.com/volcengine/veadk-go/apps"
+	"github.com/volcengine/veadk-go/apps/agentkit_server_app"
+	"github.com/volcengine/veadk-go/log"
+	"github.com/volcengine/veadk-go/tool/builtin_tools"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/tool"
+)
+
+func main() {
+	ctx := context.Background()
+
+	veSearch, err := builtin_tools.NewVeSearchTool(&builtin_tools.VeSearchConfig{})
+	if err != nil {
+		log.Errorf("NewVeSearchTool failed: %v", err)
+		return
+	}
+
+	rootAgent, err := veagent.New(&veagent.Config{
+		Config: llmagent.Config{
+			Name:        "vesearch_tool_agent",
+			Description: "可联网检索资讯/新闻",
+			Instruction: "可联网检索资讯/新闻",
+			Tools:       []tool.Tool{veSearch},
+		},
+	})
+
+	if err != nil {
+		log.Error("Failed to create agent: %v", err)
+		return
+	}
+
+	app := agentkit_server_app.NewAgentkitServerApp(apps.DefaultApiConfig())
+
+	err = app.Run(ctx, &apps.RunConfig{
+		AgentLoader: agent.NewSingleLoader(rootAgent),
+	})
+	if err != nil {
+		log.Errorf("Run failed: %v", err)
+	}
+}


### PR DESCRIPTION
## 背景
`vesearch` 内置工具已在 #64 合入，但 `examples/tool/` 下还没有对应示例。

## 改动
- 新增 `examples/tool/vesearch/agent_with_vesearch_tool.go`，演示如何把 `vesearch` 工具挂到 Agent 上并通过 agentkit server app 运行。
- 风格与现有 `examples/tool/link_reader` 示例保持一致。

## 测试
- `go build ./examples/tool/vesearch/...`、`go vet` 通过。