### PR TITLE
feat: add TLS observability auto setup

### DIFF
--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -129,10 +129,12 @@ opentelemetry:
 }
 
 func TestObservabilityConfig_EnvMapping(t *testing.T) {
-	os.Setenv("OBSERVABILITY_OPENTELEMETRY_APMPLUS_ENDPOINT", "http://env-endpoint")
-	defer func() {
-		os.Unsetenv("OBSERVABILITY_OPENTELEMETRY_APMPLUS_ENDPOINT")
-	}()
+	t.Setenv("OBSERVABILITY_OPENTELEMETRY_APMPLUS_ENDPOINT", "http://env-endpoint")
+	t.Setenv("OBSERVABILITY_OPENTELEMETRY_TLS_PROJECT_NAME", "tls-project")
+	t.Setenv("OBSERVABILITY_OPENTELEMETRY_TLS_TRACE_INSTANCE_NAME", "tls-trace")
+	t.Setenv("OBSERVABILITY_OPENTELEMETRY_TLS_API_ENDPOINT", "https://tls-cn-beijing.volces.com")
+	t.Setenv("OBSERVABILITY_OPENTELEMETRY_TLS_AUTO_CREATE", "false")
+	t.Setenv("OBSERVABILITY_OPENTELEMETRY_TLS_SESSION_TOKEN", "tls-token")
 
 	config := &ObservabilityConfig{}
 	config.MapEnvToConfig()
@@ -140,6 +142,13 @@ func TestObservabilityConfig_EnvMapping(t *testing.T) {
 	assert.NotNil(t, config.OpenTelemetry)
 	assert.NotNil(t, config.OpenTelemetry.ApmPlus)
 	assert.Equal(t, "http://env-endpoint", config.OpenTelemetry.ApmPlus.Endpoint)
+	assert.NotNil(t, config.OpenTelemetry.TLS)
+	assert.Equal(t, "tls-project", config.OpenTelemetry.TLS.ProjectName)
+	assert.Equal(t, "tls-trace", config.OpenTelemetry.TLS.TraceInstanceName)
+	assert.Equal(t, "https://tls-cn-beijing.volces.com", config.OpenTelemetry.TLS.APIEndpoint)
+	assert.Equal(t, "tls-token", config.OpenTelemetry.TLS.SessionToken)
+	assert.NotNil(t, config.OpenTelemetry.TLS.AutoCreate)
+	assert.False(t, *config.OpenTelemetry.TLS.AutoCreate)
 }
 
 func TestObservabilityConfig_Priority(t *testing.T) {

--- a/configs/observability.go
+++ b/configs/observability.go
@@ -16,6 +16,7 @@ package configs
 
 import (
 	"os"
+	"strconv"
 
 	"github.com/volcengine/veadk-go/utils"
 )
@@ -37,12 +38,19 @@ const (
 	EnvObservabilityOpenTelemetryCozeLoopServiceName = "OBSERVABILITY_OPENTELEMETRY_COZELOOP_SERVICE_NAME"
 
 	// TLS
-	EnvObservabilityOpenTelemetryTLSEndpoint    = "OBSERVABILITY_OPENTELEMETRY_TLS_ENDPOINT"
-	EnvObservabilityOpenTelemetryTLSServiceName = "OBSERVABILITY_OPENTELEMETRY_TLS_SERVICE_NAME"
-	EnvObservabilityOpenTelemetryTLSRegion      = "OBSERVABILITY_OPENTELEMETRY_TLS_REGION"
-	EnvObservabilityOpenTelemetryTLSTopicID     = "OBSERVABILITY_OPENTELEMETRY_TLS_TOPIC_ID"
-	EnvObservabilityOpenTelemetryTLSAccessKey   = "OBSERVABILITY_OPENTELEMETRY_TLS_ACCESS_KEY"
-	EnvObservabilityOpenTelemetryTLSSecretKey   = "OBSERVABILITY_OPENTELEMETRY_TLS_SECRET_KEY"
+	EnvObservabilityOpenTelemetryTLSEndpoint          = "OBSERVABILITY_OPENTELEMETRY_TLS_ENDPOINT"
+	EnvObservabilityOpenTelemetryTLSServiceName       = "OBSERVABILITY_OPENTELEMETRY_TLS_SERVICE_NAME"
+	EnvObservabilityOpenTelemetryTLSRegion            = "OBSERVABILITY_OPENTELEMETRY_TLS_REGION"
+	EnvObservabilityOpenTelemetryTLSTopicID           = "OBSERVABILITY_OPENTELEMETRY_TLS_TOPIC_ID"
+	EnvObservabilityOpenTelemetryTLSAccessKey         = "OBSERVABILITY_OPENTELEMETRY_TLS_ACCESS_KEY"
+	EnvObservabilityOpenTelemetryTLSSecretKey         = "OBSERVABILITY_OPENTELEMETRY_TLS_SECRET_KEY"
+	EnvObservabilityOpenTelemetryTLSProjectID         = "OBSERVABILITY_OPENTELEMETRY_TLS_PROJECT_ID"
+	EnvObservabilityOpenTelemetryTLSProjectName       = "OBSERVABILITY_OPENTELEMETRY_TLS_PROJECT_NAME"
+	EnvObservabilityOpenTelemetryTLSTraceInstanceID   = "OBSERVABILITY_OPENTELEMETRY_TLS_TRACE_INSTANCE_ID"
+	EnvObservabilityOpenTelemetryTLSTraceInstanceName = "OBSERVABILITY_OPENTELEMETRY_TLS_TRACE_INSTANCE_NAME"
+	EnvObservabilityOpenTelemetryTLSAPIEndpoint       = "OBSERVABILITY_OPENTELEMETRY_TLS_API_ENDPOINT"
+	EnvObservabilityOpenTelemetryTLSAutoCreate        = "OBSERVABILITY_OPENTELEMETRY_TLS_AUTO_CREATE"
+	EnvObservabilityOpenTelemetryTLSSessionToken      = "OBSERVABILITY_OPENTELEMETRY_TLS_SESSION_TOKEN"
 
 	// File
 	EnvObservabilityOpenTelemetryFilePath = "OBSERVABILITY_OPENTELEMETRY_FILE_PATH"
@@ -80,12 +88,19 @@ type CozeLoopExporterConfig struct {
 }
 
 type TLSExporterConfig struct {
-	Endpoint    string `yaml:"endpoint"`
-	ServiceName string `yaml:"service_name"`
-	Region      string `yaml:"region"`
-	TopicID     string `yaml:"topic_id"`
-	AccessKey   string `yaml:"access_key"`
-	SecretKey   string `yaml:"secret_key"`
+	Endpoint          string `yaml:"endpoint"`
+	ServiceName       string `yaml:"service_name"`
+	Region            string `yaml:"region"`
+	TopicID           string `yaml:"topic_id"`
+	AccessKey         string `yaml:"access_key"`
+	SecretKey         string `yaml:"secret_key"`
+	SessionToken      string `yaml:"session_token"`
+	ProjectID         string `yaml:"project_id"`
+	ProjectName       string `yaml:"project_name"`
+	TraceInstanceID   string `yaml:"trace_instance_id"`
+	TraceInstanceName string `yaml:"trace_instance_name"`
+	APIEndpoint       string `yaml:"api_endpoint"`
+	AutoCreate        *bool  `yaml:"auto_create"`
 }
 
 type FileConfig struct {
@@ -211,6 +226,50 @@ func (c *ObservabilityConfig) MapEnvToConfig() {
 		}
 		ot.TLS.SecretKey = v
 	}
+	if v := utils.GetEnvWithDefault(EnvObservabilityOpenTelemetryTLSSessionToken); v != "" {
+		if ot.TLS == nil {
+			ot.TLS = &TLSExporterConfig{}
+		}
+		ot.TLS.SessionToken = v
+	}
+	if v := utils.GetEnvWithDefault(EnvObservabilityOpenTelemetryTLSProjectID); v != "" {
+		if ot.TLS == nil {
+			ot.TLS = &TLSExporterConfig{}
+		}
+		ot.TLS.ProjectID = v
+	}
+	if v := utils.GetEnvWithDefault(EnvObservabilityOpenTelemetryTLSProjectName); v != "" {
+		if ot.TLS == nil {
+			ot.TLS = &TLSExporterConfig{}
+		}
+		ot.TLS.ProjectName = v
+	}
+	if v := utils.GetEnvWithDefault(EnvObservabilityOpenTelemetryTLSTraceInstanceID); v != "" {
+		if ot.TLS == nil {
+			ot.TLS = &TLSExporterConfig{}
+		}
+		ot.TLS.TraceInstanceID = v
+	}
+	if v := utils.GetEnvWithDefault(EnvObservabilityOpenTelemetryTLSTraceInstanceName); v != "" {
+		if ot.TLS == nil {
+			ot.TLS = &TLSExporterConfig{}
+		}
+		ot.TLS.TraceInstanceName = v
+	}
+	if v := utils.GetEnvWithDefault(EnvObservabilityOpenTelemetryTLSAPIEndpoint); v != "" {
+		if ot.TLS == nil {
+			ot.TLS = &TLSExporterConfig{}
+		}
+		ot.TLS.APIEndpoint = v
+	}
+	if v := utils.GetEnvWithDefault(EnvObservabilityOpenTelemetryTLSAutoCreate); v != "" {
+		if ot.TLS == nil {
+			ot.TLS = &TLSExporterConfig{}
+		}
+		ot.TLS.AutoCreate = new(bool)
+		parsed, err := strconv.ParseBool(v)
+		*ot.TLS.AutoCreate = err != nil || parsed
+	}
 
 	// File
 	if v := utils.GetEnvWithDefault(EnvObservabilityOpenTelemetryFilePath); v != "" {
@@ -287,14 +346,25 @@ func (c *TLSExporterConfig) Clone() *TLSExporterConfig {
 	if c == nil {
 		return nil
 	}
-	return &TLSExporterConfig{
-		Endpoint:    c.Endpoint,
-		ServiceName: c.ServiceName,
-		Region:      c.Region,
-		TopicID:     c.TopicID,
-		AccessKey:   c.AccessKey,
-		SecretKey:   c.SecretKey,
+	clone := &TLSExporterConfig{
+		Endpoint:          c.Endpoint,
+		ServiceName:       c.ServiceName,
+		Region:            c.Region,
+		TopicID:           c.TopicID,
+		AccessKey:         c.AccessKey,
+		SecretKey:         c.SecretKey,
+		SessionToken:      c.SessionToken,
+		ProjectID:         c.ProjectID,
+		ProjectName:       c.ProjectName,
+		TraceInstanceID:   c.TraceInstanceID,
+		TraceInstanceName: c.TraceInstanceName,
+		APIEndpoint:       c.APIEndpoint,
 	}
+	if c.AutoCreate != nil {
+		clone.AutoCreate = new(bool)
+		*clone.AutoCreate = *c.AutoCreate
+	}
+	return clone
 }
 
 func (c *FileConfig) Clone() *FileConfig {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1
 	github.com/volcengine/ve-tos-golang-sdk/v2 v2.7.26
+	github.com/volcengine/volc-sdk-golang v1.0.23
 	github.com/volcengine/volcengine-go-sdk v1.1.53
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.40.0
@@ -97,7 +98,6 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
-	github.com/volcengine/volc-sdk-golang v1.0.23 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.mongodb.org/mongo-driver v1.17.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/integrations/ve_tls/ve_tls.go
+++ b/integrations/ve_tls/ve_tls.go
@@ -1,0 +1,624 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ve_tls
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/volcengine/veadk-go/auth/veauth"
+	"github.com/volcengine/veadk-go/common"
+	"github.com/volcengine/veadk-go/configs"
+	"github.com/volcengine/veadk-go/utils"
+	"github.com/volcengine/volc-sdk-golang/base"
+)
+
+const (
+	DefaultRegion            = "cn-beijing"
+	DefaultProjectName       = "veadk-traces"
+	DefaultTraceInstanceName = "veadk"
+	DefaultTraceDescription  = "Created by Volcengine Agent Development Kit (VeADK)"
+	DefaultTraceTag          = "veadk"
+	DefaultProviderTagKey    = "provider"
+	DefaultProviderTagValue  = "VeADK"
+
+	ServiceName = "TLS"
+
+	EnvTLSProjectID         = "OBSERVABILITY_OPENTELEMETRY_TLS_PROJECT_ID"
+	EnvTLSProjectName       = "OBSERVABILITY_OPENTELEMETRY_TLS_PROJECT_NAME"
+	EnvTLSTraceInstanceID   = "OBSERVABILITY_OPENTELEMETRY_TLS_TRACE_INSTANCE_ID"
+	EnvTLSTraceInstanceName = "OBSERVABILITY_OPENTELEMETRY_TLS_TRACE_INSTANCE_NAME"
+	EnvTLSAPIEndpoint       = "OBSERVABILITY_OPENTELEMETRY_TLS_API_ENDPOINT"
+	EnvTLSAutoCreate        = "OBSERVABILITY_OPENTELEMETRY_TLS_AUTO_CREATE"
+	EnvTLSSessionToken      = "OBSERVABILITY_OPENTELEMETRY_TLS_SESSION_TOKEN"
+)
+
+type Config struct {
+	AK           string
+	SK           string
+	SessionToken string
+	Region       string
+	Endpoint     string
+	HTTPClient   *http.Client
+}
+
+type Client struct {
+	config     Config
+	httpClient *http.Client
+}
+
+type TraceInstance struct {
+	TraceInstanceID     string `json:"TraceInstanceId"`
+	TraceInstanceName   string `json:"TraceInstanceName"`
+	TraceInstanceStatus string `json:"TraceInstanceStatus"`
+	TraceTopicID        string `json:"TraceTopicId"`
+	TraceTopicName      string `json:"TraceTopicName"`
+	ProjectID           string `json:"ProjectId"`
+	ProjectName         string `json:"ProjectName"`
+}
+
+type Project struct {
+	ProjectID   string `json:"ProjectId"`
+	ProjectName string `json:"ProjectName"`
+	Description string `json:"Description"`
+}
+
+type APIError struct {
+	HTTPCode int
+	Code     string
+	Message  string
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	parts := []string{"TLS OpenAPI request failed"}
+	if e.HTTPCode > 0 {
+		parts = append(parts, "http="+strconv.Itoa(e.HTTPCode))
+	}
+	if e.Code != "" {
+		parts = append(parts, "code="+e.Code)
+	}
+	if e.Message != "" {
+		parts = append(parts, "message="+e.Message)
+	}
+	return strings.Join(parts, " ")
+}
+
+func New(cfg *Config) (*Client, error) {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	out := *cfg
+	out.AK = strings.TrimSpace(out.AK)
+	out.SK = strings.TrimSpace(out.SK)
+	if out.AK != "" || out.SK != "" {
+		if out.AK == "" || out.SK == "" {
+			return nil, fmt.Errorf("TLS access key and secret key must be configured together")
+		}
+	}
+	if out.AK == "" {
+		out.AK = utils.GetEnvWithDefault(common.VOLCENGINE_ACCESS_KEY, configs.GetGlobalConfig().Volcengine.AK)
+	}
+	if out.SK == "" {
+		out.SK = utils.GetEnvWithDefault(common.VOLCENGINE_SECRET_KEY, configs.GetGlobalConfig().Volcengine.SK)
+	}
+	if out.AK == "" || out.SK == "" {
+		iam, err := veauth.GetCredentialFromVeFaaSIAM()
+		if err != nil {
+			return nil, fmt.Errorf("load TLS credentials failed: %w", err)
+		}
+		out.AK = iam.AccessKeyID
+		out.SK = iam.SecretAccessKey
+		out.SessionToken = iam.SessionToken
+	}
+	if out.SessionToken == "" {
+		out.SessionToken = strings.TrimSpace(os.Getenv(EnvTLSSessionToken))
+	}
+	if out.Region == "" {
+		out.Region = firstNonEmpty(os.Getenv("REGION"), os.Getenv("AGENTKIT_TOOL_REGION"), DefaultRegion)
+	}
+	if out.Endpoint == "" {
+		out.Endpoint = firstNonEmpty(os.Getenv(EnvTLSAPIEndpoint), fmt.Sprintf("https://tls-%s.volces.com", out.Region))
+	}
+	out.Endpoint = NormalizeAPIEndpoint(out.Endpoint, out.Region)
+	if out.HTTPClient == nil {
+		out.HTTPClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	if strings.TrimSpace(out.AK) == "" || strings.TrimSpace(out.SK) == "" {
+		return nil, fmt.Errorf("TLS access key and secret key are required")
+	}
+	if strings.TrimSpace(out.Region) == "" {
+		return nil, fmt.Errorf("TLS region is required")
+	}
+	if strings.TrimSpace(out.Endpoint) == "" {
+		return nil, fmt.Errorf("TLS endpoint is required")
+	}
+	return &Client{config: out, httpClient: out.HTTPClient}, nil
+}
+
+func (c *Client) CreateLogProject(projectName string) (string, error) {
+	return c.CreateLogProjectContext(context.Background(), projectName)
+}
+
+func (c *Client) CreateLogProjectContext(ctx context.Context, projectName string) (string, error) {
+	var out struct {
+		ProjectID string `json:"ProjectId"`
+	}
+	if err := c.doJSON(ctx, http.MethodPost, "/CreateProject", nil, map[string]any{
+		"ProjectName": strings.TrimSpace(projectName),
+		"Region":      c.config.Region,
+		"Description": DefaultTraceDescription,
+		"Tags": []map[string]string{
+			{
+				"Key":   DefaultProviderTagKey,
+				"Value": DefaultProviderTagValue,
+			},
+		},
+	}, &out); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(out.ProjectID) == "" {
+		return "", fmt.Errorf("CreateProject returned empty ProjectId")
+	}
+	return strings.TrimSpace(out.ProjectID), nil
+}
+
+func (c *Client) EnsureLogProject(projectName string) (string, error) {
+	return c.EnsureLogProjectContext(context.Background(), projectName)
+}
+
+func (c *Client) EnsureLogProjectContext(ctx context.Context, projectName string) (string, error) {
+	projectName = strings.TrimSpace(projectName)
+	if projectName == "" {
+		return "", fmt.Errorf("project name is required")
+	}
+	project, ok, err := c.FindLogProjectByNameContext(ctx, projectName)
+	if err != nil {
+		return "", err
+	}
+	if ok {
+		return project.ProjectID, nil
+	}
+	projectID, err := c.CreateLogProjectContext(ctx, projectName)
+	if err != nil {
+		if IsAlreadyExists(err) {
+			project, ok, findErr := c.FindLogProjectByNameContext(ctx, projectName)
+			if findErr != nil {
+				return "", findErr
+			}
+			if ok {
+				return project.ProjectID, nil
+			}
+		}
+		return "", err
+	}
+	return projectID, nil
+}
+
+func (c *Client) FindLogProjectByNameContext(ctx context.Context, projectName string) (Project, bool, error) {
+	var out struct {
+		Projects []Project `json:"Projects"`
+		Total    int64     `json:"Total"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/DescribeProjects", map[string]string{
+		"ProjectName": strings.TrimSpace(projectName),
+		"IsFullName":  "true",
+		"PageNumber":  "1",
+		"PageSize":    "100",
+	}, nil, &out); err != nil {
+		if IsNotFound(err) {
+			return Project{}, false, nil
+		}
+		return Project{}, false, err
+	}
+	for _, project := range out.Projects {
+		if strings.TrimSpace(project.ProjectName) == projectName && strings.TrimSpace(project.ProjectID) != "" {
+			return project, true, nil
+		}
+	}
+	return Project{}, false, nil
+}
+
+func (c *Client) CreateTracingInstance(projectID, traceInstanceName string) (TraceInstance, error) {
+	return c.CreateTracingInstanceContext(context.Background(), projectID, traceInstanceName)
+}
+
+func (c *Client) CreateTracingInstanceContext(ctx context.Context, projectID, traceInstanceName string) (TraceInstance, error) {
+	var out struct {
+		TraceInstanceID string `json:"TraceInstanceId"`
+	}
+	if err := c.doJSON(ctx, http.MethodPost, "/CreateTraceInstance", nil, map[string]any{
+		"TraceInstanceName": strings.TrimSpace(traceInstanceName),
+		"ProjectId":         strings.TrimSpace(projectID),
+		"Description":       DefaultTraceDescription,
+	}, &out, map[string]string{"TraceTag": DefaultTraceTag}); err != nil {
+		return TraceInstance{}, err
+	}
+	if strings.TrimSpace(out.TraceInstanceID) == "" {
+		return TraceInstance{}, fmt.Errorf("CreateTraceInstance returned empty TraceInstanceId")
+	}
+	return c.DescribeTracingInstanceContext(ctx, out.TraceInstanceID)
+}
+
+func (c *Client) EnsureTracingInstance(projectID, traceInstanceName string) (TraceInstance, error) {
+	return c.EnsureTracingInstanceContext(context.Background(), projectID, traceInstanceName)
+}
+
+func (c *Client) EnsureTracingInstanceContext(ctx context.Context, projectID, traceInstanceName string) (TraceInstance, error) {
+	projectID = strings.TrimSpace(projectID)
+	traceInstanceName = strings.TrimSpace(traceInstanceName)
+	if projectID == "" {
+		return TraceInstance{}, fmt.Errorf("project id is required")
+	}
+	if traceInstanceName == "" {
+		return TraceInstance{}, fmt.Errorf("trace instance name is required")
+	}
+	instance, ok, err := c.FindTracingInstanceByNameContext(ctx, projectID, traceInstanceName)
+	if err != nil {
+		return TraceInstance{}, err
+	}
+	if ok {
+		return c.ensureTraceTopicID(ctx, instance)
+	}
+	instance, err = c.CreateTracingInstanceContext(ctx, projectID, traceInstanceName)
+	if err != nil {
+		if IsAlreadyExists(err) {
+			instance, ok, findErr := c.FindTracingInstanceByNameContext(ctx, projectID, traceInstanceName)
+			if findErr != nil {
+				return TraceInstance{}, findErr
+			}
+			if ok {
+				return c.ensureTraceTopicID(ctx, instance)
+			}
+		}
+		return TraceInstance{}, err
+	}
+	return c.ensureTraceTopicID(ctx, instance)
+}
+
+func (c *Client) FindTracingInstanceByNameContext(ctx context.Context, projectID, traceInstanceName string) (TraceInstance, bool, error) {
+	var out struct {
+		TraceInstances []TraceInstance `json:"TraceInstances"`
+		Total          int64           `json:"Total"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/DescribeTraceInstances", map[string]string{
+		"ProjectId":         strings.TrimSpace(projectID),
+		"TraceInstanceName": strings.TrimSpace(traceInstanceName),
+		"PageNumber":        "1",
+		"PageSize":          "100",
+	}, nil, &out); err != nil {
+		if IsNotFound(err) {
+			return TraceInstance{}, false, nil
+		}
+		return TraceInstance{}, false, err
+	}
+	for _, instance := range out.TraceInstances {
+		if strings.TrimSpace(instance.TraceInstanceName) == traceInstanceName && strings.TrimSpace(instance.TraceInstanceID) != "" {
+			return instance, true, nil
+		}
+	}
+	return TraceInstance{}, false, nil
+}
+
+func (c *Client) DescribeTracingInstance(traceInstanceID string) (TraceInstance, error) {
+	return c.DescribeTracingInstanceContext(context.Background(), traceInstanceID)
+}
+
+func (c *Client) DescribeTracingInstanceContext(ctx context.Context, traceInstanceID string) (TraceInstance, error) {
+	var out TraceInstance
+	if err := c.doJSON(ctx, http.MethodGet, "/DescribeTraceInstance", map[string]string{
+		"TraceInstanceId": strings.TrimSpace(traceInstanceID),
+	}, nil, &out); err != nil {
+		return TraceInstance{}, err
+	}
+	return out, nil
+}
+
+func (c *Client) ensureTraceTopicID(ctx context.Context, instance TraceInstance) (TraceInstance, error) {
+	if strings.TrimSpace(instance.TraceTopicID) != "" {
+		return instance, nil
+	}
+	if strings.TrimSpace(instance.TraceInstanceID) == "" {
+		return instance, nil
+	}
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return TraceInstance{}, ctx.Err()
+			case <-time.After(time.Duration(attempt) * 250 * time.Millisecond):
+			}
+		}
+		described, err := c.DescribeTracingInstanceContext(ctx, instance.TraceInstanceID)
+		if err != nil {
+			return TraceInstance{}, err
+		}
+		if strings.TrimSpace(described.TraceTopicID) != "" {
+			return described, nil
+		}
+	}
+	return instance, nil
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path string, params map[string]string, body any, out any, extraHeaders ...map[string]string) error {
+	if c == nil {
+		return fmt.Errorf("TLS client is nil")
+	}
+	u, err := url.Parse(c.config.Endpoint)
+	if err != nil {
+		return err
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/" + strings.TrimLeft(path, "/")
+	query := u.Query()
+	for key, value := range params {
+		if strings.TrimSpace(value) != "" {
+			query.Set(key, value)
+		}
+	}
+	u.RawQuery = query.Encode()
+
+	var payload []byte
+	if body == nil {
+		payload = []byte("{}")
+	} else {
+		payload, err = json.Marshal(body)
+		if err != nil {
+			return err
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Tls-Apiversion", "0.3.0")
+	for _, headers := range extraHeaders {
+		for key, value := range headers {
+			if strings.TrimSpace(key) != "" && strings.TrimSpace(value) != "" {
+				req.Header.Set(key, value)
+			}
+		}
+	}
+	req = c.signRequest(req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return DecodeAPIError(resp.StatusCode, responseBody)
+	}
+	if out == nil || len(bytes.TrimSpace(responseBody)) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(responseBody, out); err != nil {
+		return fmt.Errorf("decode TLS OpenAPI response failed: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) signRequest(req *http.Request) *http.Request {
+	req = base.Credentials{
+		AccessKeyID:     c.config.AK,
+		SecretAccessKey: c.config.SK,
+		SessionToken:    c.config.SessionToken,
+		Service:         ServiceName,
+		Region:          c.config.Region,
+	}.Sign(req)
+	return req
+}
+
+func DecodeAPIError(status int, body []byte) error {
+	body = bytes.TrimSpace(body)
+	apiErr := &APIError{HTTPCode: status}
+	var raw map[string]any
+	if len(body) > 0 && json.Unmarshal(body, &raw) == nil {
+		apiErr.Code = stringFromAny(firstPresent(raw, "Code", "code", "errorCode", "ErrorCode"))
+		apiErr.Message = stringFromAny(firstPresent(raw, "Message", "message", "errorMessage", "ErrorMessage"))
+		if nested, ok := firstPresent(raw, "Error", "error").(map[string]any); ok {
+			if apiErr.Code == "" {
+				apiErr.Code = stringFromAny(firstPresent(nested, "Code", "code", "errorCode", "ErrorCode"))
+			}
+			if apiErr.Message == "" {
+				apiErr.Message = stringFromAny(firstPresent(nested, "Message", "message", "errorMessage", "ErrorMessage"))
+			}
+		}
+	}
+	if apiErr.Code == "" && apiErr.Message == "" && len(body) > 0 {
+		apiErr.Message = string(body)
+	}
+	return apiErr
+}
+
+func IsAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		code := strings.ToLower(apiErr.Code)
+		message := strings.ToLower(apiErr.Message)
+		return strings.Contains(code, "already") ||
+			strings.Contains(code, "exist") ||
+			strings.Contains(message, "already exist") ||
+			strings.Contains(message, "already exists")
+	}
+	return false
+}
+
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		code := strings.ToLower(apiErr.Code)
+		message := strings.ToLower(apiErr.Message)
+		normalizedCode := strings.ReplaceAll(code, "_", "")
+		normalizedCode = strings.ReplaceAll(normalizedCode, "-", "")
+		return strings.Contains(normalizedCode, "notexist") ||
+			strings.Contains(normalizedCode, "notfound") ||
+			strings.Contains(message, "does not exist") ||
+			strings.Contains(message, "not found")
+	}
+	return false
+}
+
+func NormalizeAPIEndpoint(endpoint, region string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return fmt.Sprintf("https://tls-%s.volces.com", firstNonEmpty(region, DefaultRegion))
+	}
+	if !strings.Contains(endpoint, "://") {
+		endpoint = "https://" + endpoint
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return endpoint
+	}
+	u.Path = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return strings.TrimRight(u.String(), "/")
+}
+
+func APIEndpointFromOTLPEndpoint(endpoint, region string) string {
+	endpoint = NormalizeOTLPEndpoint(endpoint, region)
+	if !strings.Contains(endpoint, "://") {
+		endpoint = "https://" + endpoint
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return NormalizeAPIEndpoint(endpoint, region)
+	}
+	u.Path = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	u.Host = stripDefaultOTLPPort(u.Host)
+	return NormalizeAPIEndpoint(u.String(), region)
+}
+
+func NormalizeOTLPEndpoint(endpoint, region string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return fmt.Sprintf("https://tls-%s.volces.com:4318/v1/traces", firstNonEmpty(region, DefaultRegion))
+	}
+	if !strings.Contains(endpoint, "://") {
+		endpoint = "https://" + endpoint
+	}
+	return endpoint
+}
+
+func DefaultProjectNameForService(serviceName string) string {
+	name := normalizeResourceName(serviceName, 22)
+	if name == "" {
+		return DefaultProjectName
+	}
+	return normalizeResourceName(name+"-traces", 30)
+}
+
+func DefaultTraceInstanceNameForService(serviceName string) string {
+	name := normalizeResourceName(serviceName, 30)
+	if name == "" {
+		return DefaultTraceInstanceName
+	}
+	return name
+}
+
+func normalizeResourceName(input string, maxLen int) string {
+	input = strings.ToLower(strings.TrimSpace(input))
+	var b strings.Builder
+	lastHyphen := false
+	for _, r := range input {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			b.WriteRune(r)
+			lastHyphen = false
+			continue
+		}
+		if !lastHyphen {
+			b.WriteByte('-')
+			lastHyphen = true
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if maxLen > 0 && len(out) > maxLen {
+		out = strings.Trim(out[:maxLen], "-")
+	}
+	for len(out) > 0 && len(out) < 3 {
+		out += "-x"
+		out = strings.Trim(out, "-")
+	}
+	return out
+}
+
+func stripDefaultOTLPPort(host string) string {
+	if strings.TrimSpace(host) == "" {
+		return host
+	}
+	if h, p, err := net.SplitHostPort(host); err == nil && (p == "4318" || p == "4317") {
+		if strings.Contains(h, ":") {
+			return "[" + h + "]"
+		}
+		return h
+	}
+	return host
+}
+
+func firstPresent(values map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := values[key]; ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func stringFromAny(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/integrations/ve_tls/ve_tls_test.go
+++ b/integrations/ve_tls/ve_tls_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ve_tls
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureLogProjectAndTracingInstance(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+	var signedRequests int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		if strings.TrimSpace(r.Header.Get("Authorization")) != "" && r.Header.Get("X-Security-Token") == "token" {
+			signedRequests++
+		}
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/DescribeProjects":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"Projects": []any{},
+				"Total":    0,
+			})
+		case "/CreateProject":
+			var body struct {
+				ProjectName string `json:"ProjectName"`
+				Tags        []struct {
+					Key   string `json:"Key"`
+					Value string `json:"Value"`
+				} `json:"Tags"`
+			}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "project-name", body.ProjectName)
+			require.Len(t, body.Tags, 1)
+			assert.Equal(t, DefaultProviderTagKey, body.Tags[0].Key)
+			assert.Equal(t, DefaultProviderTagValue, body.Tags[0].Value)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ProjectId": "project-1",
+			})
+		case "/DescribeTraceInstances":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"TraceInstances": []any{},
+				"Total":          0,
+			})
+		case "/CreateTraceInstance":
+			assert.Equal(t, DefaultTraceTag, r.Header.Get("TraceTag"))
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"TraceInstanceId": "trace-1",
+			})
+		case "/DescribeTraceInstance":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"TraceInstanceId":   "trace-1",
+				"TraceInstanceName": "trace-name",
+				"TraceTopicId":      "topic-1",
+				"ProjectId":         "project-1",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client, err := New(&Config{
+		AK:           "ak",
+		SK:           "sk",
+		SessionToken: "token",
+		Region:       "cn-beijing",
+		Endpoint:     server.URL,
+	})
+	require.NoError(t, err)
+
+	projectID, err := client.EnsureLogProjectContext(context.Background(), "project-name")
+	require.NoError(t, err)
+	assert.Equal(t, "project-1", projectID)
+
+	instance, err := client.EnsureTracingInstanceContext(context.Background(), projectID, "trace-name")
+	require.NoError(t, err)
+	assert.Equal(t, "topic-1", instance.TraceTopicID)
+
+	assert.Equal(t, []string{
+		"/DescribeProjects",
+		"/CreateProject",
+		"/DescribeTraceInstances",
+		"/CreateTraceInstance",
+		"/DescribeTraceInstance",
+	}, paths)
+	assert.Equal(t, len(paths), signedRequests)
+}
+
+func TestNewRejectsPartialCredentials(t *testing.T) {
+	client, err := New(&Config{
+		SK:       "sk",
+		Region:   "cn-beijing",
+		Endpoint: "http://127.0.0.1:12345",
+	})
+	assert.Nil(t, client)
+	assert.ErrorContains(t, err, "must be configured together")
+}
+
+func TestEndpointNormalization(t *testing.T) {
+	assert.Equal(t, "https://tls-cn-beijing.volces.com", NormalizeAPIEndpoint("tls-cn-beijing.volces.com", "cn-beijing"))
+	assert.Equal(t, "http://127.0.0.1:12345", NormalizeAPIEndpoint("http://127.0.0.1:12345/openapi", "cn-beijing"))
+	assert.Equal(t, "https://tls-cn-beijing.volces.com", APIEndpointFromOTLPEndpoint("https://tls-cn-beijing.volces.com:4318/v1/traces", "cn-beijing"))
+	assert.Equal(t, "https://tls-cn-beijing.volces.com:8443", APIEndpointFromOTLPEndpoint("https://tls-cn-beijing.volces.com:8443/v1/traces", "cn-beijing"))
+}
+
+func TestDefaultNamesForService(t *testing.T) {
+	assert.Equal(t, "tls-copilot-traces", DefaultProjectNameForService("TLS Copilot"))
+	assert.Equal(t, "tls-copilot", DefaultTraceInstanceNameForService("TLS Copilot"))
+	assert.Equal(t, DefaultProjectName, DefaultProjectNameForService("!!!"))
+	assert.Equal(t, DefaultTraceInstanceName, DefaultTraceInstanceNameForService("!!!"))
+}
+
+func TestIsNotFound(t *testing.T) {
+	assert.True(t, IsNotFound(&APIError{HTTPCode: http.StatusNotFound, Code: "ProjectNotExists", Message: "Project does not exist."}))
+	assert.True(t, IsNotFound(&APIError{HTTPCode: http.StatusNotFound, Code: "TraceInstanceNotFound"}))
+	assert.False(t, IsNotFound(&APIError{HTTPCode: http.StatusBadRequest, Code: "InvalidArgument"}))
+}

--- a/observability/exporter.go
+++ b/observability/exporter.go
@@ -19,12 +19,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
+	"github.com/volcengine/veadk-go/auth/veauth"
 	"github.com/volcengine/veadk-go/configs"
+	"github.com/volcengine/veadk-go/integrations/ve_tls"
 	"github.com/volcengine/veadk-go/log"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
@@ -160,13 +164,173 @@ func NewAPMPlusExporter(ctx context.Context, cfg *configs.ApmPlusConfig) (trace.
 
 // NewTLSExporter creates an OTLP HTTP exporter for Volcano TLS.
 func NewTLSExporter(ctx context.Context, cfg *configs.TLSExporterConfig) (trace.SpanExporter, error) {
-	endpoint := cfg.Endpoint
-	return createTraceClient(ctx, endpoint, "", map[string]string{
-		"x-tls-otel-tracetopic": cfg.TopicID,
-		"x-tls-otel-ak":         cfg.AccessKey,
-		"x-tls-otel-sk":         cfg.SecretKey,
-		"x-tls-otel-region":     cfg.Region,
-	})
+	prepared, dynamicAuth, err := prepareTLSExporterConfig(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	headers := tlsOTLPHeaders(prepared)
+	if !dynamicAuth {
+		return otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(prepared.Endpoint), otlptracehttp.WithHeaders(headers))
+	}
+	return otlptracehttp.New(ctx,
+		otlptracehttp.WithEndpointURL(prepared.Endpoint),
+		otlptracehttp.WithHeaders(headers),
+		otlptracehttp.WithHTTPClient(&http.Client{
+			Transport: &tlsOTLPAuthRoundTripper{base: http.DefaultTransport},
+		}),
+	)
+}
+
+// PrepareTLSExporterConfig fills TLS observability defaults and ensures a trace topic.
+func PrepareTLSExporterConfig(ctx context.Context, cfg *configs.TLSExporterConfig) (*configs.TLSExporterConfig, error) {
+	prepared, _, err := prepareTLSExporterConfig(ctx, cfg)
+	return prepared, err
+}
+
+func prepareTLSExporterConfig(ctx context.Context, cfg *configs.TLSExporterConfig) (*configs.TLSExporterConfig, bool, error) {
+	if cfg == nil {
+		return nil, false, fmt.Errorf("TLS observability config is required")
+	}
+	out := cfg.Clone()
+	out.Region = firstNonEmpty(out.Region, os.Getenv(configs.EnvObservabilityOpenTelemetryTLSRegion), os.Getenv("REGION"), os.Getenv("AGENTKIT_TOOL_REGION"), ve_tls.DefaultRegion)
+	out.ServiceName = firstNonEmpty(out.ServiceName, os.Getenv(configs.EnvObservabilityOpenTelemetryTLSServiceName), os.Getenv(configs.EnvOtelServiceName), ve_tls.DefaultTraceInstanceName)
+	out.Endpoint = ve_tls.NormalizeOTLPEndpoint(firstNonEmpty(out.Endpoint, os.Getenv(configs.EnvObservabilityOpenTelemetryTLSEndpoint), os.Getenv(OTELExporterOTLPEndpointEnvKey)), out.Region)
+	out.AccessKey = firstNonEmpty(out.AccessKey, os.Getenv(configs.EnvObservabilityOpenTelemetryTLSAccessKey))
+	out.SecretKey = firstNonEmpty(out.SecretKey, os.Getenv(configs.EnvObservabilityOpenTelemetryTLSSecretKey))
+	if out.AccessKey != "" || out.SecretKey != "" {
+		if out.AccessKey == "" || out.SecretKey == "" {
+			return nil, false, fmt.Errorf("TLS access key and secret key must be configured together")
+		}
+	}
+	out.SessionToken = firstNonEmpty(out.SessionToken, os.Getenv(configs.EnvObservabilityOpenTelemetryTLSSessionToken))
+	out.ProjectID = firstNonEmpty(out.ProjectID, os.Getenv(configs.EnvObservabilityOpenTelemetryTLSProjectID))
+	out.ProjectName = firstNonEmpty(out.ProjectName, os.Getenv(configs.EnvObservabilityOpenTelemetryTLSProjectName))
+	out.TraceInstanceID = firstNonEmpty(out.TraceInstanceID, os.Getenv(configs.EnvObservabilityOpenTelemetryTLSTraceInstanceID))
+	out.TraceInstanceName = firstNonEmpty(out.TraceInstanceName, os.Getenv(configs.EnvObservabilityOpenTelemetryTLSTraceInstanceName))
+	out.APIEndpoint = ve_tls.NormalizeAPIEndpoint(firstNonEmpty(out.APIEndpoint, os.Getenv(configs.EnvObservabilityOpenTelemetryTLSAPIEndpoint), ve_tls.APIEndpointFromOTLPEndpoint(out.Endpoint, out.Region)), out.Region)
+
+	if strings.TrimSpace(out.TopicID) == "" {
+		if !tlsAutoCreateEnabled(out) {
+			return nil, false, fmt.Errorf("TLS trace topic is required when %s=false", configs.EnvObservabilityOpenTelemetryTLSAutoCreate)
+		}
+		client, err := ve_tls.New(&ve_tls.Config{
+			AK:           out.AccessKey,
+			SK:           out.SecretKey,
+			SessionToken: out.SessionToken,
+			Region:       out.Region,
+			Endpoint:     out.APIEndpoint,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+		if strings.TrimSpace(out.TraceInstanceID) != "" {
+			instance, err := client.DescribeTracingInstanceContext(ctx, out.TraceInstanceID)
+			if err != nil {
+				return nil, false, fmt.Errorf("describe TLS trace instance %q failed: %w", out.TraceInstanceID, err)
+			}
+			out.TopicID = strings.TrimSpace(instance.TraceTopicID)
+		} else {
+			projectID := strings.TrimSpace(out.ProjectID)
+			if projectID == "" {
+				projectName := firstNonEmpty(out.ProjectName, ve_tls.DefaultProjectNameForService(out.ServiceName))
+				var err error
+				projectID, err = client.EnsureLogProjectContext(ctx, projectName)
+				if err != nil {
+					return nil, false, fmt.Errorf("ensure TLS log project %q failed: %w", projectName, err)
+				}
+				out.ProjectID = projectID
+			}
+			instanceName := firstNonEmpty(out.TraceInstanceName, ve_tls.DefaultTraceInstanceNameForService(out.ServiceName))
+			instance, err := client.EnsureTracingInstanceContext(ctx, projectID, instanceName)
+			if err != nil {
+				return nil, false, fmt.Errorf("ensure TLS trace instance %q failed: %w", instanceName, err)
+			}
+			out.TraceInstanceID = firstNonEmpty(out.TraceInstanceID, instance.TraceInstanceID)
+			out.TraceInstanceName = firstNonEmpty(out.TraceInstanceName, instance.TraceInstanceName)
+			out.TopicID = strings.TrimSpace(instance.TraceTopicID)
+		}
+	}
+	if strings.TrimSpace(out.TopicID) == "" {
+		return nil, false, fmt.Errorf("TLS trace topic is required")
+	}
+	dynamicAuth := strings.TrimSpace(out.AccessKey) == "" || strings.TrimSpace(out.SecretKey) == ""
+	return out, dynamicAuth, nil
+}
+
+func tlsAutoCreateEnabled(cfg *configs.TLSExporterConfig) bool {
+	if cfg != nil && cfg.AutoCreate != nil {
+		return *cfg.AutoCreate
+	}
+	value := strings.TrimSpace(os.Getenv(configs.EnvObservabilityOpenTelemetryTLSAutoCreate))
+	if value == "" {
+		return true
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return true
+	}
+	return parsed
+}
+
+func tlsOTLPHeaders(cfg *configs.TLSExporterConfig) map[string]string {
+	headers := map[string]string{
+		"x-tls-otel-tracetopic": strings.TrimSpace(cfg.TopicID),
+		"x-tls-otel-region":     strings.TrimSpace(cfg.Region),
+	}
+	if strings.TrimSpace(cfg.AccessKey) != "" && strings.TrimSpace(cfg.SecretKey) != "" {
+		headers["x-tls-otel-ak"] = strings.TrimSpace(cfg.AccessKey)
+		headers["x-tls-otel-sk"] = strings.TrimSpace(cfg.SecretKey)
+		addTLSSessionTokenMap(headers, cfg.SessionToken)
+	}
+	return headers
+}
+
+type tlsOTLPAuthRoundTripper struct {
+	base http.RoundTripper
+}
+
+func (t *tlsOTLPAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ak, sk, sessionToken := veauth.GetAuthInfo()
+	if strings.TrimSpace(ak) == "" || strings.TrimSpace(sk) == "" {
+		return nil, fmt.Errorf("TLS OTLP credentials are required")
+	}
+	next := req.Clone(req.Context())
+	next.Header = req.Header.Clone()
+	next.Header.Set("x-tls-otel-ak", strings.TrimSpace(ak))
+	next.Header.Set("x-tls-otel-sk", strings.TrimSpace(sk))
+	addTLSSessionTokenHeaders(next.Header, sessionToken)
+	base := http.RoundTripper(http.DefaultTransport)
+	if t != nil && t.base != nil {
+		base = t.base
+	}
+	return base.RoundTrip(next)
+}
+
+func addTLSSessionTokenHeaders(headers http.Header, token string) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return
+	}
+	headers.Set("x-tls-otel-token", token)
+	headers.Set("X-Security-Token", token)
+}
+
+func addTLSSessionTokenMap(headers map[string]string, token string) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return
+	}
+	headers["x-tls-otel-token"] = token
+	headers["X-Security-Token"] = token
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 // NewFileExporter creates a span exporter that writes traces to a file.
@@ -221,9 +385,6 @@ func NewMultiExporter(ctx context.Context, cfg *configs.OpenTelemetryConfig) (tr
 	}
 
 	if cfg.TLS != nil {
-		if cfg.TLS.Endpoint == "" || cfg.TLS.AccessKey == "" || cfg.TLS.SecretKey == "" {
-			return nil, fmt.Errorf("TLS endpoint, access_key and secret_key are required")
-		}
 		if exp, err := NewTLSExporter(ctx, cfg.TLS); err == nil {
 			exporters = append(exporters, exp)
 			log.Info("Exporting spans to TLS", "endpoint", cfg.TLS.Endpoint, "service_name", cfg.TLS.ServiceName)

--- a/observability/exporter_test.go
+++ b/observability/exporter_test.go
@@ -16,10 +16,18 @@ package observability
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/volcengine/veadk-go/common"
+	"github.com/volcengine/veadk-go/configs"
 )
 
 func TestCreateLogClient(t *testing.T) {
@@ -90,4 +98,117 @@ func TestCreateMetricClient(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, exporter)
 	})
+}
+
+func TestPrepareTLSExporterConfigAutoCreate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/DescribeProjects":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"Projects": []any{},
+				"Total":    0,
+			})
+		case "/CreateProject":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ProjectId": "project-1",
+			})
+		case "/DescribeTraceInstances":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"TraceInstances": []any{},
+				"Total":          0,
+			})
+		case "/CreateTraceInstance":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"TraceInstanceId": "trace-1",
+			})
+		case "/DescribeTraceInstance":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"TraceInstanceId":   "trace-1",
+				"TraceInstanceName": "tls-copilot",
+				"TraceTopicId":      "topic-1",
+				"ProjectId":         "project-1",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	prepared, err := PrepareTLSExporterConfig(context.Background(), &configs.TLSExporterConfig{
+		Endpoint:    "https://tls-cn-beijing.volces.com:4318/v1/traces",
+		APIEndpoint: server.URL,
+		AccessKey:   "ak",
+		SecretKey:   "sk",
+		Region:      "cn-beijing",
+		ServiceName: "TLS Copilot",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "topic-1", prepared.TopicID)
+	assert.Equal(t, "project-1", prepared.ProjectID)
+	assert.Equal(t, "tls-copilot", prepared.TraceInstanceName)
+	assert.Equal(t, server.URL, prepared.APIEndpoint)
+}
+
+func TestPrepareTLSExporterConfigRequiresTopicWhenAutoCreateDisabled(t *testing.T) {
+	autoCreate := false
+	prepared, err := PrepareTLSExporterConfig(context.Background(), &configs.TLSExporterConfig{
+		AutoCreate: &autoCreate,
+	})
+
+	assert.Nil(t, prepared)
+	assert.ErrorContains(t, err, "TLS trace topic is required")
+}
+
+func TestPrepareTLSExporterConfigRejectsPartialTLSCredentials(t *testing.T) {
+	prepared, err := PrepareTLSExporterConfig(context.Background(), &configs.TLSExporterConfig{
+		TopicID:   "topic-1",
+		AccessKey: " ",
+		SecretKey: " ==",
+	})
+
+	assert.Nil(t, prepared)
+	assert.ErrorContains(t, err, "must be configured together")
+}
+
+func TestNewMultiExporterAllowsTLSDynamicAuth(t *testing.T) {
+	exp, err := NewMultiExporter(context.Background(), &configs.OpenTelemetryConfig{
+		TLS: &configs.TLSExporterConfig{
+			Endpoint: "http://localhost:4318/v1/traces",
+			Region:   "cn-beijing",
+			TopicID:  "topic-1",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+}
+
+func TestTLSOTLPAuthRoundTripperUsesAuthInfo(t *testing.T) {
+	t.Setenv(common.VOLCENGINE_ACCESS_KEY, "env-ak")
+	t.Setenv(common.VOLCENGINE_SECRET_KEY, "env-sk")
+
+	rt := &tlsOTLPAuthRoundTripper{base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "env-ak", req.Header.Get("x-tls-otel-ak"))
+		assert.Equal(t, "env-sk", req.Header.Get("x-tls-otel-sk"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+	req, err := http.NewRequest(http.MethodPost, "http://localhost/v1/traces", nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }


### PR DESCRIPTION
### Summary
- Add ve_tls OpenAPI helper for TLS project/trace instance setup.
- Extend TLS exporter config/env support and auto-resolve TraceTopicId.
- Align TLS CreateProject/CreateTraceInstance metadata with veadk-python.

### Tests
- go test ./integrations/ve_tls ./observability ./configs

### Compatibility
A v0.0.5-based compatibility branch is also available for tls_copilot_new_arch integration: runninggo:codex/tls-observability-veadk-v005
