### PR TITLE
feat(observability): record model response id

### DIFF
--- a/model/ark.go
+++ b/model/ark.go
@@ -348,6 +348,7 @@ func (m *arkModel) generateStream(ctx context.Context, arkReq *arkmodel.CreateCh
 		var accToolCalls []*arkmodel.ToolCall
 		var finalUsage *arkmodel.Usage
 		var finishReason arkmodel.FinishReason
+		var responseID string
 
 		for {
 			chunk, err := stream.Recv()
@@ -357,6 +358,10 @@ func (m *arkModel) generateStream(ctx context.Context, arkReq *arkmodel.CreateCh
 			if err != nil {
 				yield(nil, fmt.Errorf("ark: stream recv failed: %w", err))
 				return
+			}
+
+			if chunk.ID != "" {
+				responseID = chunk.ID
 			}
 
 			if chunk.Usage != nil {
@@ -435,7 +440,7 @@ func (m *arkModel) generateStream(ctx context.Context, arkReq *arkmodel.CreateCh
 			if finishReason == "" {
 				finishReason = arkmodel.FinishReasonStop
 			}
-			finalResp := m.buildArkFinalResponse(textBuffer.String(), reasoningBuffer.String(), accToolCalls, finalUsage, finishReason)
+			finalResp := m.buildArkFinalResponse(textBuffer.String(), reasoningBuffer.String(), accToolCalls, finalUsage, finishReason, responseID)
 			yield(finalResp, nil)
 		}
 	}
@@ -489,6 +494,7 @@ func (m *arkModel) convertArkResponse(resp *arkmodel.ChatCompletionResponse) (*m
 		UsageMetadata: buildArkUsageMetadata(&resp.Usage),
 		CustomMetadata: map[string]any{
 			"response_model": resp.Model,
+			"response_id":    resp.ID,
 		},
 	}
 
@@ -496,7 +502,7 @@ func (m *arkModel) convertArkResponse(resp *arkmodel.ChatCompletionResponse) (*m
 }
 
 // buildArkFinalResponse builds the final LLMResponse at end of stream.
-func (m *arkModel) buildArkFinalResponse(text, reasoningText string, toolCalls []*arkmodel.ToolCall, usage *arkmodel.Usage, finishReason arkmodel.FinishReason) *model.LLMResponse {
+func (m *arkModel) buildArkFinalResponse(text, reasoningText string, toolCalls []*arkmodel.ToolCall, usage *arkmodel.Usage, finishReason arkmodel.FinishReason, responseID string) *model.LLMResponse {
 	var parts []*genai.Part
 
 	if reasoningText != "" {
@@ -529,6 +535,7 @@ func (m *arkModel) buildArkFinalResponse(text, reasoningText string, toolCalls [
 		UsageMetadata: buildArkUsageMetadata(usage),
 		CustomMetadata: map[string]any{
 			"response_model": m.name,
+			"response_id":    responseID,
 		},
 	}
 }

--- a/model/ark_test.go
+++ b/model/ark_test.go
@@ -119,6 +119,7 @@ func TestArkModel_Generate(t *testing.T) {
 			},
 			CustomMetadata: map[string]any{
 				"response_model": "test-model",
+				"response_id":    "chatcmpl-test",
 			},
 			FinishReason: genai.FinishReasonStop,
 		}
@@ -326,6 +327,7 @@ func TestArkModel_GenerateStream(t *testing.T) {
 		assert.Equal(t, genai.FinishReasonStop, finalResp.FinishReason)
 		assert.NotNil(t, finalResp.UsageMetadata)
 		assert.Equal(t, int32(10), finalResp.UsageMetadata.PromptTokenCount)
+		assert.Equal(t, "chatcmpl-test", finalResp.CustomMetadata["response_id"])
 	})
 }
 

--- a/model/openai.go
+++ b/model/openai.go
@@ -465,6 +465,7 @@ func (m *openAIModel) generateStream(ctx context.Context, openaiReq *openAIReque
 		var finalUsage usage
 		var usageFound bool
 		var finishedReason string
+		var responseID string
 
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -480,6 +481,10 @@ func (m *openAIModel) generateStream(ctx context.Context, openaiReq *openAIReque
 			var chunk response
 			if err := json.Unmarshal([]byte(data), &chunk); err != nil {
 				continue
+			}
+
+			if chunk.ID != "" {
+				responseID = chunk.ID
 			}
 
 			if chunk.Usage != nil {
@@ -574,7 +579,7 @@ func (m *openAIModel) generateStream(ctx context.Context, openaiReq *openAIReque
 			if finishedReason == "" {
 				finishedReason = "stop"
 			}
-			finalResp := m.buildFinalResponse(textBuffer.String(), reasoningBuffer.String(), toolCalls, u, finishedReason)
+			finalResp := m.buildFinalResponse(textBuffer.String(), reasoningBuffer.String(), toolCalls, u, finishedReason, responseID)
 			yield(finalResp, nil)
 		}
 	}
@@ -684,6 +689,7 @@ func (m *openAIModel) convertResponse(resp *response) (*model.LLMResponse, error
 		},
 		CustomMetadata: map[string]any{
 			"response_model": resp.Model,
+			"response_id":    resp.ID,
 		},
 	}
 
@@ -693,7 +699,7 @@ func (m *openAIModel) convertResponse(resp *response) (*model.LLMResponse, error
 	return llmResp, nil
 }
 
-func (m *openAIModel) buildFinalResponse(text string, reasoningText string, toolCalls []toolCall, usage *usage, finishReason string) *model.LLMResponse {
+func (m *openAIModel) buildFinalResponse(text string, reasoningText string, toolCalls []toolCall, usage *usage, finishReason, responseID string) *model.LLMResponse {
 	var parts []*genai.Part
 
 	if reasoningText != "" {
@@ -729,6 +735,7 @@ func (m *openAIModel) buildFinalResponse(text string, reasoningText string, tool
 		UsageMetadata: buildUsageMetadata(usage),
 		CustomMetadata: map[string]any{
 			"response_model": m.name,
+			"response_id":    responseID,
 		},
 	}
 

--- a/model/openai_test.go
+++ b/model/openai_test.go
@@ -243,6 +243,7 @@ func TestModel_Generate(t *testing.T) {
 				},
 				CustomMetadata: map[string]any{
 					"response_model": "test-model",
+					"response_id":    "chatcmpl-test",
 				},
 				FinishReason: genai.FinishReasonStop,
 			},
@@ -269,6 +270,7 @@ func TestModel_Generate(t *testing.T) {
 				},
 				CustomMetadata: map[string]any{
 					"response_model": "test-model",
+					"response_id":    "chatcmpl-test",
 				},
 				FinishReason: genai.FinishReasonStop,
 			},
@@ -324,6 +326,7 @@ func TestModel_GenerateStream(t *testing.T) {
 			llm := newTestModel(t, server)
 
 			var partialText strings.Builder
+			var finalResp *model.LLMResponse
 			for resp, err := range llm.GenerateContent(t.Context(), tt.req, true) {
 				if (err != nil) != tt.wantErr {
 					t.Errorf("GenerateContent() error = %v, wantErr %v", err, tt.wantErr)
@@ -331,12 +334,16 @@ func TestModel_GenerateStream(t *testing.T) {
 				}
 				if resp.Partial && len(resp.Content.Parts) > 0 {
 					partialText.WriteString(resp.Content.Parts[0].Text)
+				} else {
+					finalResp = resp
 				}
 			}
 
 			if got := partialText.String(); got != tt.want {
 				t.Errorf("GenerateContent() streaming = %q, want %q", got, tt.want)
 			}
+			require.NotNil(t, finalResp)
+			require.Equal(t, "chatcmpl-test", finalResp.CustomMetadata["response_id"])
 		})
 	}
 }
@@ -1314,7 +1321,7 @@ func TestBuildFinalResponse_EmptyToolCallFiltering(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp := m.buildFinalResponse("", "", tt.toolCalls, nil, "stop")
+			resp := m.buildFinalResponse("", "", tt.toolCalls, nil, "stop", "chatcmpl-test")
 
 			var functionCalls []*genai.FunctionCall
 			for _, part := range resp.Content.Parts {

--- a/observability/plugin.go
+++ b/observability/plugin.go
@@ -312,6 +312,7 @@ func (p *adkObservabilityPlugin) AfterModel(ctx agent.CallbackContext, resp *mod
 		if m, ok := resp.CustomMetadata["response_model"].(string); ok && m != "" {
 			finalModelName = m
 		}
+		setResponseIDAttribute(context.Context(ctx), resp.CustomMetadata)
 	}
 
 	if resp.UsageMetadata != nil {
@@ -343,6 +344,14 @@ func (p *adkObservabilityPlugin) AfterModel(ctx agent.CallbackContext, resp *mod
 	}
 
 	return nil, nil
+}
+
+func setResponseIDAttribute(ctx context.Context, metadata map[string]any) {
+	responseID, ok := metadata["response_id"].(string)
+	if !ok || responseID == "" {
+		return
+	}
+	trace.SpanFromContext(ctx).SetAttributes(attribute.String(AttrGenAIResponseID, responseID))
 }
 
 func (p *adkObservabilityPlugin) recordFinalResponseMetrics(ctx agent.CallbackContext, meta *spanMetadata, finalModelName string) {

--- a/observability/plugin_test.go
+++ b/observability/plugin_test.go
@@ -1,9 +1,13 @@
 package observability
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -60,4 +64,17 @@ func TestRegisterTraceMappingIfPossible(t *testing.T) {
 		ok := registerTraceMappingIfPossible(registry, trace.SpanContext{}, veadkSC)
 		assert.False(t, ok)
 	})
+}
+
+func TestSetResponseIDAttribute(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	ctx, span := provider.Tracer("test").Start(context.Background(), "model")
+
+	setResponseIDAttribute(ctx, map[string]any{"response_id": "chatcmpl-test"})
+	span.End()
+
+	spans := recorder.Ended()
+	assert.Len(t, spans, 1)
+	assert.Contains(t, spans[0].Attributes(), attribute.String(AttrGenAIResponseID, "chatcmpl-test"))
 }


### PR DESCRIPTION
## 背景
对齐 veadk-python #577，在模型 span 上记录 OpenTelemetry GenAI 语义属性 `gen_ai.response.id`。对于 Ark，该 ID 可用于关联服务端请求与排查问题。

## 改动
- OpenAI-compatible 与 ARK SDK 的非流式响应将 provider response ID 写入 `LLMResponse.CustomMetadata`。
- 流式响应在聚合 chunk 时保留 response ID，并写入最终响应元数据。
- Observability `AfterModel` 回调读取元数据，在当前模型 span 上设置 `gen_ai.response.id`。
- 新增 OpenAI、ARK 流式/非流式及 span attribute 单元测试。

## 测试
- `GOTOOLCHAIN=go1.25.0 go test -mod=readonly -v -race -count=1 -shuffle=on ./...` 通过。
- `GOTOOLCHAIN=go1.25.0 go build -mod=readonly -v ./...` 通过。
- `GOTOOLCHAIN=go1.25.0 go mod tidy -diff` 无变更。
- `golangci-lint run --timeout=10m --new-from-rev=upstream/main` 通过（0 issues）。
- 本地 golangci-lint v2 全仓检查仍报告 upstream/main 已有的 18 个问题，本 PR 未新增 lint 问题。