### PR TITLE
fix(model): serialize empty function arguments as object

### DIFF
--- a/model/ark.go
+++ b/model/ark.go
@@ -257,7 +257,7 @@ func (m *arkModel) convertGenAIContentToArk(content *genai.Content) ([]*arkmodel
 				textParts = append(textParts, string(part.InlineData.Data))
 			}
 		} else if part.FunctionCall != nil {
-			argsJSON, err := json.Marshal(part.FunctionCall.Args)
+			argsJSON, err := marshalFunctionCallArgs(part.FunctionCall.Args)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal function args: %w", err)
 			}
@@ -270,7 +270,7 @@ func (m *arkModel) convertGenAIContentToArk(content *genai.Content) ([]*arkmodel
 				Type: arkmodel.ToolTypeFunction,
 				Function: arkmodel.FunctionCall{
 					Name:      part.FunctionCall.Name,
-					Arguments: string(argsJSON),
+					Arguments: argsJSON,
 				},
 			})
 		}

--- a/model/ark_test.go
+++ b/model/ark_test.go
@@ -441,6 +441,28 @@ func TestArkModel_ConvertContentWithFunctionResponse(t *testing.T) {
 	assert.Equal(t, "call_abc123", msgs[0].ToolCallID)
 }
 
+func TestArkModel_ConvertContentWithNilFunctionCallArgs(t *testing.T) {
+	am := &arkModel{name: "test-model", config: &ArkClientConfig{}}
+	content := &genai.Content{
+		Role: "model",
+		Parts: []*genai.Part{
+			{
+				FunctionCall: &genai.FunctionCall{
+					ID:   "call_empty",
+					Name: "get_time",
+					Args: nil,
+				},
+			},
+		},
+	}
+
+	msgs, err := am.convertGenAIContentToArk(content)
+	assert.NoError(t, err)
+	assert.Len(t, msgs, 1)
+	assert.Len(t, msgs[0].ToolCalls, 1)
+	assert.Equal(t, "{}", msgs[0].ToolCalls[0].Function.Arguments)
+}
+
 func TestArkModel_BuildUsageMetadata(t *testing.T) {
 	t.Run("normal_usage", func(t *testing.T) {
 		usage := &arkmodel.Usage{

--- a/model/convert.go
+++ b/model/convert.go
@@ -65,6 +65,18 @@ func extractTextFromContent(content *genai.Content) string {
 	return strings.Join(texts, "\n")
 }
 
+func marshalFunctionCallArgs(args map[string]any) (string, error) {
+	if len(args) == 0 {
+		return "{}", nil
+	}
+
+	argsJSON, err := json.Marshal(args)
+	if err != nil {
+		return "", err
+	}
+	return string(argsJSON), nil
+}
+
 // convertFunctionParameters converts a genai.FunctionDeclaration's parameters to a map.
 func convertFunctionParameters(fn *genai.FunctionDeclaration) map[string]any {
 	if fn.ParametersJsonSchema != nil {

--- a/model/openai.go
+++ b/model/openai.go
@@ -369,7 +369,7 @@ func (m *openAIModel) convertGenAIContent(content *genai.Content) ([]message, er
 				},
 			})
 		} else if part.FunctionCall != nil {
-			argsJSON, err := json.Marshal(part.FunctionCall.Args)
+			argsJSON, err := marshalFunctionCallArgs(part.FunctionCall.Args)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal function args: %w", err)
 			}
@@ -382,7 +382,7 @@ func (m *openAIModel) convertGenAIContent(content *genai.Content) ([]message, er
 				Type: "function",
 				Function: functionCall{
 					Name:      part.FunctionCall.Name,
-					Arguments: string(argsJSON),
+					Arguments: argsJSON,
 				},
 			})
 		}

--- a/model/openai_test.go
+++ b/model/openai_test.go
@@ -2081,6 +2081,37 @@ func TestConvertContent(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "function_call_with_nil_args",
+			content: &genai.Content{
+				Role: "model",
+				Parts: []*genai.Part{
+					{
+						FunctionCall: &genai.FunctionCall{
+							ID:   "call_empty",
+							Name: "get_time",
+							Args: nil,
+						},
+					},
+				},
+			},
+			want: []message{
+				{
+					Role: "assistant",
+					ToolCalls: []toolCall{
+						{
+							ID:   "call_empty",
+							Type: "function",
+							Function: functionCall{
+								Name:      "get_time",
+								Arguments: `{}`,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "inline_image_data",
 			content: &genai.Content{
 				Role: "user",


### PR DESCRIPTION
## 背景
Issue #72 指出：零参数 `FunctionCall` 在 session round-trip 后可能得到 nil `Args`，当前 OpenAI 与 ARK 适配器会将其序列化为字符串 `"null"`，不符合 OpenAI tool call 对参数对象的约定，并可能影响后续工具调用。

## 改动
- 新增统一的 function arguments 序列化逻辑，将 nil/空 map 输出为 `"{}"`。
- OpenAI-compatible 与 ARK SDK 两条消息转换路径统一使用该逻辑。
- 新增两条回归测试，覆盖 nil `Args` 的请求转换结果。

## 测试
- `GOTOOLCHAIN=go1.25.0 go test -mod=readonly -v -race -count=1 -shuffle=on ./...` 通过。
- `GOTOOLCHAIN=go1.25.0 go build -mod=readonly -v ./...` 通过。
- `GOTOOLCHAIN=go1.25.0 go mod tidy -diff` 无变更。
- `golangci-lint run --timeout=10m --new-from-rev=upstream/main` 通过（0 issues）。
- 本地 golangci-lint v2 全仓检查仍报告 upstream/main 已有的 18 个问题，本 PR 未新增 lint 问题。

Closes #72