### PR TITLE
feat(model): support structured output schemas

### DIFF
--- a/examples/structured_output/main.go
+++ b/examples/structured_output/main.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+
+	veagent "github.com/volcengine/veadk-go/agent/llmagent"
+	"github.com/volcengine/veadk-go/log"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/cmd/launcher"
+	"google.golang.org/adk/cmd/launcher/full"
+	"google.golang.org/adk/session"
+	"google.golang.org/genai"
+)
+
+func main() {
+	ctx := context.Background()
+
+	rootAgent, err := veagent.New(&veagent.Config{
+		Config: llmagent.Config{
+			Name:        "structured_output_agent",
+			Description: "Agent that returns structured weather information.",
+			Instruction: "Return the requested weather information using the output schema.",
+			OutputSchema: &genai.Schema{
+				Type:  genai.TypeObject,
+				Title: "weather_response",
+				Properties: map[string]*genai.Schema{
+					"location":    {Type: genai.TypeString},
+					"temperature": {Type: genai.TypeNumber},
+					"unit": {
+						Type: genai.TypeString,
+						Enum: []string{"celsius", "fahrenheit"},
+					},
+				},
+				Required: []string{"location", "temperature", "unit"},
+			},
+		},
+	})
+	if err != nil {
+		log.Errorf("NewLLMAgent failed: %v", err)
+		return
+	}
+
+	config := &launcher.Config{
+		AgentLoader:    agent.NewSingleLoader(rootAgent),
+		SessionService: session.InMemoryService(),
+	}
+	l := full.NewLauncher()
+	if err = l.Execute(ctx, config, os.Args[1:]); err != nil {
+		log.Errorf("Run failed: %v\n\n%s", err, l.CommandLineSyntax())
+	}
+}

--- a/model/ark.go
+++ b/model/ark.go
@@ -159,7 +159,17 @@ func (m *arkModel) convertArkRequest(req *model.LLMRequest) (*arkmodel.CreateCha
 		if len(req.Config.StopSequences) > 0 {
 			arkReq.Stop = req.Config.StopSequences
 		}
-		if req.Config.ResponseMIMEType == "application/json" {
+		if schema := convertResponseSchema(req.Config); schema != nil {
+			arkReq.ResponseFormat = &arkmodel.ResponseFormat{
+				Type: arkmodel.ResponseFormatJSONSchema,
+				JSONSchema: &arkmodel.ResponseFormatJSONSchemaJSONSchemaParam{
+					Name:        schema.Name,
+					Description: schema.Description,
+					Schema:      schema.Schema,
+					Strict:      true,
+				},
+			}
+		} else if req.Config.ResponseMIMEType == "application/json" {
 			arkReq.ResponseFormat = &arkmodel.ResponseFormat{
 				Type: arkmodel.ResponseFormatJsonObject,
 			}

--- a/model/ark_test.go
+++ b/model/ark_test.go
@@ -419,6 +419,37 @@ func TestArkModel_ConvertRequest(t *testing.T) {
 		assert.Equal(t, arkmodel.ToolTypeFunction, arkReq.Tools[0].Type)
 		assert.Equal(t, "search", arkReq.Tools[0].Function.Name)
 	})
+
+	t.Run("structured_output", func(t *testing.T) {
+		am := &arkModel{name: "test-model", config: &ArkClientConfig{}}
+		req := &model.LLMRequest{
+			Contents: genai.Text("Return weather data"),
+			Config: &genai.GenerateContentConfig{
+				ResponseMIMEType: "application/json",
+				ResponseJsonSchema: map[string]any{
+					"title": "weather",
+					"type":  "object",
+					"properties": map[string]any{
+						"temperature": map[string]any{"type": "number"},
+					},
+					"required": []string{"temperature"},
+				},
+			},
+		}
+
+		arkReq, err := am.convertArkRequest(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, arkReq.ResponseFormat)
+		assert.Equal(t, arkmodel.ResponseFormatJSONSchema, arkReq.ResponseFormat.Type)
+		assert.Equal(t, "weather", arkReq.ResponseFormat.JSONSchema.Name)
+		assert.True(t, arkReq.ResponseFormat.JSONSchema.Strict)
+		assert.Equal(t, []string{"temperature"}, arkReq.ResponseFormat.JSONSchema.Schema.(map[string]any)["required"])
+
+		req.Config.ResponseJsonSchema = nil
+		arkReq, err = am.convertArkRequest(req)
+		assert.NoError(t, err)
+		assert.Equal(t, arkmodel.ResponseFormatJsonObject, arkReq.ResponseFormat.Type)
+	})
 }
 
 func TestArkModel_ConvertContentWithFunctionResponse(t *testing.T) {

--- a/model/convert.go
+++ b/model/convert.go
@@ -139,5 +139,103 @@ func schemaToMap(schema *genai.Schema) map[string]any {
 	if len(schema.Enum) > 0 {
 		result["enum"] = schema.Enum
 	}
+	if len(schema.Required) > 0 {
+		result["required"] = schema.Required
+	}
+	if schema.Title != "" {
+		result["title"] = schema.Title
+	}
+	if schema.Format != "" {
+		result["format"] = schema.Format
+	}
+	if len(schema.AnyOf) > 0 {
+		anyOf := make([]any, 0, len(schema.AnyOf))
+		for _, item := range schema.AnyOf {
+			anyOf = append(anyOf, schemaToMap(item))
+		}
+		result["anyOf"] = anyOf
+	}
+	if schema.Default != nil {
+		result["default"] = schema.Default
+	}
+	if schema.Minimum != nil {
+		result["minimum"] = *schema.Minimum
+	}
+	if schema.Maximum != nil {
+		result["maximum"] = *schema.Maximum
+	}
+	if schema.MinLength != nil {
+		result["minLength"] = *schema.MinLength
+	}
+	if schema.MaxLength != nil {
+		result["maxLength"] = *schema.MaxLength
+	}
+	if schema.MinItems != nil {
+		result["minItems"] = *schema.MinItems
+	}
+	if schema.MaxItems != nil {
+		result["maxItems"] = *schema.MaxItems
+	}
+	if schema.Pattern != "" {
+		result["pattern"] = schema.Pattern
+	}
 	return result
+}
+
+type structuredOutputSchema struct {
+	Name        string
+	Description string
+	Schema      map[string]any
+}
+
+func convertResponseSchema(config *genai.GenerateContentConfig) *structuredOutputSchema {
+	if config == nil {
+		return nil
+	}
+
+	var schema map[string]any
+	if config.ResponseJsonSchema != nil {
+		schema = tryConvertJsonSchema(config.ResponseJsonSchema)
+	}
+	if schema == nil && config.ResponseSchema != nil {
+		schema = schemaToMap(config.ResponseSchema)
+	}
+	if schema == nil {
+		return nil
+	}
+
+	name, _ := schema["title"].(string)
+	description, _ := schema["description"].(string)
+	return &structuredOutputSchema{
+		Name:        sanitizeResponseSchemaName(name),
+		Description: description,
+		Schema:      schema,
+	}
+}
+
+func sanitizeResponseSchemaName(name string) string {
+	if name == "" {
+		return "response"
+	}
+
+	var sanitized strings.Builder
+	for _, r := range name {
+		if sanitized.Len() >= 64 {
+			break
+		}
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_',
+			r == '-':
+			sanitized.WriteRune(r)
+		default:
+			sanitized.WriteByte('_')
+		}
+	}
+	if sanitized.Len() == 0 {
+		return "response"
+	}
+	return sanitized.String()
 }

--- a/model/openai.go
+++ b/model/openai.go
@@ -163,7 +163,15 @@ func (r openAIRequest) MarshalJSON() ([]byte, error) {
 }
 
 type responseFormat struct {
-	Type string `json:"type"`
+	Type       string                    `json:"type"`
+	JSONSchema *jsonSchemaResponseFormat `json:"json_schema,omitempty"`
+}
+
+type jsonSchemaResponseFormat struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Schema      map[string]any `json:"schema"`
+	Strict      bool           `json:"strict"`
 }
 
 type message struct {
@@ -276,7 +284,17 @@ func (m *openAIModel) convertOpenAIRequest(req *model.LLMRequest) (*openAIReques
 		if len(req.Config.StopSequences) > 0 {
 			openaiReq.Stop = req.Config.StopSequences
 		}
-		if req.Config.ResponseMIMEType == "application/json" {
+		if schema := convertResponseSchema(req.Config); schema != nil {
+			openaiReq.ResponseFormat = &responseFormat{
+				Type: "json_schema",
+				JSONSchema: &jsonSchemaResponseFormat{
+					Name:        schema.Name,
+					Description: schema.Description,
+					Schema:      schema.Schema,
+					Strict:      true,
+				},
+			}
+		} else if req.Config.ResponseMIMEType == "application/json" {
 			openaiReq.ResponseFormat = &responseFormat{Type: "json_object"}
 		}
 	}

--- a/model/openai_test.go
+++ b/model/openai_test.go
@@ -866,6 +866,78 @@ func TestConvertLegacyParameters(t *testing.T) {
 	}
 }
 
+func TestConvertResponseSchema(t *testing.T) {
+	legacySchema := &genai.Schema{
+		Type:        genai.TypeObject,
+		Title:       "weather response",
+		Description: "Structured weather data",
+		Properties: map[string]*genai.Schema{
+			"location": {
+				Type: genai.TypeString,
+			},
+			"forecast": {
+				Type: genai.TypeObject,
+				Properties: map[string]*genai.Schema{
+					"temperature": {Type: genai.TypeNumber},
+				},
+				Required: []string{"temperature"},
+			},
+		},
+		Required: []string{"location", "forecast"},
+	}
+
+	got := convertResponseSchema(&genai.GenerateContentConfig{ResponseSchema: legacySchema})
+	require.NotNil(t, got)
+	require.Equal(t, "weather_response", got.Name)
+	require.Equal(t, "Structured weather data", got.Description)
+	require.Equal(t, []string{"location", "forecast"}, got.Schema["required"])
+	forecast := got.Schema["properties"].(map[string]any)["forecast"].(map[string]any)
+	require.Equal(t, []string{"temperature"}, forecast["required"])
+
+	jsonSchema := map[string]any{
+		"title": "custom-schema",
+		"type":  "object",
+	}
+	got = convertResponseSchema(&genai.GenerateContentConfig{
+		ResponseSchema:     legacySchema,
+		ResponseJsonSchema: jsonSchema,
+	})
+	require.Equal(t, "custom-schema", got.Name)
+	require.Equal(t, jsonSchema, got.Schema)
+}
+
+func TestOpenAIModel_ConvertStructuredOutput(t *testing.T) {
+	m := &openAIModel{name: "test-model"}
+	req := &model.LLMRequest{
+		Contents: genai.Text("Return weather data"),
+		Config: &genai.GenerateContentConfig{
+			ResponseMIMEType: "application/json",
+			ResponseSchema: &genai.Schema{
+				Type:  genai.TypeObject,
+				Title: "weather",
+				Properties: map[string]*genai.Schema{
+					"temperature": {Type: genai.TypeNumber},
+				},
+				Required: []string{"temperature"},
+			},
+		},
+	}
+
+	got, err := m.convertOpenAIRequest(req)
+	require.NoError(t, err)
+	require.NotNil(t, got.ResponseFormat)
+	require.Equal(t, "json_schema", got.ResponseFormat.Type)
+	require.NotNil(t, got.ResponseFormat.JSONSchema)
+	require.Equal(t, "weather", got.ResponseFormat.JSONSchema.Name)
+	require.True(t, got.ResponseFormat.JSONSchema.Strict)
+	require.Equal(t, []string{"temperature"}, got.ResponseFormat.JSONSchema.Schema["required"])
+
+	req.Config.ResponseSchema = nil
+	got, err = m.convertOpenAIRequest(req)
+	require.NoError(t, err)
+	require.Equal(t, &responseFormat{Type: "json_object"}, got.ResponseFormat)
+}
+
 func TestModel_StreamingToolCalls(t *testing.T) {
 	// Test server that streams tool calls with Index field
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## 背景
ADK 的 `llmagent.Config.OutputSchema` 会写入 `GenerateContentConfig.ResponseSchema`，但当前 VeADK-Go 的 OpenAI 与 ARK 适配器只发送 `json_object`，导致字段约束、required 和嵌套 schema 丢失。

## 改动
- 支持将 `ResponseSchema` / `ResponseJsonSchema` 转换为 OpenAI-compatible `response_format.type=json_schema`。
- ARK SDK 路径使用 `ResponseFormatJSONSchema`，并与 Python 实现保持 `strict: true`。
- `ResponseJsonSchema` 优先于 legacy `ResponseSchema`；仅设置 `application/json` 时继续回退到原有 `json_object`。
- 补充 nested required、title、format、anyOf 与常用约束字段转换，并生成合法的 schema name。
- 新增 OpenAI/ARK 请求转换测试与 `examples/structured_output` 示例。

## 测试
- `GOTOOLCHAIN=go1.25.0 go test -mod=readonly -v -race -count=1 -shuffle=on ./...` 通过。
- `GOTOOLCHAIN=go1.25.0 go build -mod=readonly -v ./...` 通过（包含 structured output 示例）。
- `GOTOOLCHAIN=go1.25.0 go mod tidy -diff` 无变更。
- `golangci-lint run --timeout=10m --new-from-rev=upstream/main` 通过（0 issues）。
- 本地 golangci-lint v2 全仓检查仍报告 upstream/main 已有的 18 个问题，本 PR 未新增 lint 问题。