### PR TITLE
feat(apps): add configurable server lifecycle and extensions

### DIFF
--- a/apps/agentkit_server_app/app.go
+++ b/apps/agentkit_server_app/app.go
@@ -32,35 +32,94 @@ import (
 
 const serverName = "agentkit server"
 
-type agentkitServerApp struct {
+// AgentkitServerApp combines the simple API, A2A and ADK REST server while
+// allowing embedders to add routes and middleware around the shared router.
+type AgentkitServerApp struct {
 	*apps.ApiConfig
+	routeSetups []RouteSetup
+	middleware  []mux.MiddlewareFunc
 }
 
-func NewAgentkitServerApp(config *apps.ApiConfig) apps.BasicApp {
-	return &agentkitServerApp{
-		ApiConfig: config,
+// RouteSetup adds application-specific routes after VeADK's exact built-in
+// routes and before the ADK REST/WebUI fallback routes.
+type RouteSetup func(router *mux.Router, config *apps.RunConfig) error
+
+// Option configures AgentkitServerApp extensions.
+type Option func(*AgentkitServerApp)
+
+// WithRouteSetup adds one non-nil route setup callback.
+func WithRouteSetup(setup RouteSetup) Option {
+	return func(app *AgentkitServerApp) {
+		if setup != nil {
+			app.routeSetups = append(app.routeSetups, setup)
+		}
 	}
 }
 
-func (a *agentkitServerApp) Run(ctx context.Context, config *apps.RunConfig) error {
+// WithMiddleware installs middleware in declaration order. Nil middleware is
+// ignored.
+func WithMiddleware(middleware ...mux.MiddlewareFunc) Option {
+	return func(app *AgentkitServerApp) {
+		for _, item := range middleware {
+			if item != nil {
+				app.middleware = append(app.middleware, item)
+			}
+		}
+	}
+}
+
+func NewAgentkitServerApp(config *apps.ApiConfig, options ...Option) *AgentkitServerApp {
+	if config == nil {
+		config = apps.DefaultApiConfig()
+	}
+	app := &AgentkitServerApp{
+		ApiConfig: config,
+	}
+	for _, option := range options {
+		if option != nil {
+			option(app)
+		}
+	}
+	return app
+}
+
+func (a *AgentkitServerApp) Run(ctx context.Context, config *apps.RunConfig) error {
 	return apps.Run(ctx, config, a)
 }
 
-func (a *agentkitServerApp) SetupRouters(router *mux.Router, config *apps.RunConfig) error {
+func (a *AgentkitServerApp) SetupRouters(router *mux.Router, config *apps.RunConfig) error {
+	if router == nil {
+		return apps.NewSetupError("validate router", fmt.Errorf("router is required"))
+	}
+	if config == nil || config.AgentLoader == nil || config.AgentLoader.RootAgent() == nil {
+		return apps.NewSetupError("validate agent loader", fmt.Errorf("root agent is required"))
+	}
+	for _, middleware := range a.middleware {
+		router.Use(middleware)
+	}
+
 	var err error
 
 	//setup simple app routers
-	simpleApp := simple_app.NewAgentkitSimpleApp(a.ApiConfig)
-	err = simpleApp.SetupRouters(router, config)
-	if err != nil {
-		return fmt.Errorf("setup simple app routers failed: %w", err)
+	if a.IsSimpleAPIEnabled() {
+		simpleApp := simple_app.NewAgentkitSimpleApp(a.ApiConfig)
+		err = simpleApp.SetupRouters(router, config)
+		if err != nil {
+			return apps.NewSetupError("setup simple API routes", err)
+		}
 	}
 
 	//setup a2a routers
 	a2aApp := a2a_app.NewAgentkitA2AServerApp(a.ApiConfig)
 	err = a2aApp.SetupRouters(router, config)
 	if err != nil {
-		return fmt.Errorf("setup simple app routers failed: %w", err)
+		return apps.NewSetupError("setup A2A routes", err)
+	}
+
+	for _, setup := range a.routeSetups {
+		if err = setup(router, config); err != nil {
+			return apps.NewSetupError("setup custom routes", err)
+		}
 	}
 
 	launchConfig := &launcher.Config{
@@ -73,23 +132,24 @@ func (a *agentkitServerApp) SetupRouters(router *mux.Router, config *apps.RunCon
 		TelemetryOptions: config.TelemetryOptions,
 	}
 
-	// setup webui routers
-	webuiLauncher := webui.NewLauncher()
-	_, err = webuiLauncher.Parse([]string{
-		"--api_server_address", a.GetAPIPath(),
-	})
+	if a.IsWebUIEnabled() {
+		// setup webui routers
+		webuiLauncher := webui.NewLauncher()
+		_, err = webuiLauncher.Parse([]string{
+			"--api_server_address", a.GetAPIPath(),
+		})
 
-	if err != nil {
-		return fmt.Errorf("webuiLauncher parse parames failed: %w", err)
+		if err != nil {
+			return apps.NewSetupError("parse WebUI parameters", err)
+		}
+
+		err = webuiLauncher.SetupSubrouters(router, launchConfig)
+		if err != nil {
+			return apps.NewSetupError("setup WebUI routes", err)
+		}
+
+		webuiLauncher.UserMessage(a.GetWebUrl(), log.Println)
 	}
-
-	//webuiLauncher.AddSubrouter(router, w.config.pathPrefix, w.config.backendAddress)
-	err = webuiLauncher.SetupSubrouters(router, launchConfig)
-	if err != nil {
-		return fmt.Errorf("setup webui routers failed: %w", err)
-	}
-
-	webuiLauncher.UserMessage(a.GetWebUrl(), log.Println)
 
 	// setup web api routers
 	// Create the ADK REST API handler
@@ -102,14 +162,13 @@ func (a *agentkitServerApp) SetupRouters(router *mux.Router, config *apps.RunCon
 		PluginConfig:    config.PluginConfig,
 	})
 	if err != nil {
-		return fmt.Errorf("create adk rest server failed: %w", err)
+		return apps.NewSetupError("create ADK REST server", err)
 	}
 
-	// Wrap it with CORS middleware
-	corsHandler := corsWithArgs(a.GetWebUrl())(apiHandler)
-
-	// Wrap with OpenTelemetry instrumentation first, then add to router
-	wrappedHandler := observability.HTTPMiddleware(http.StripPrefix(a.ApiPathPrefix, corsHandler))
+	var wrappedHandler http.Handler = http.StripPrefix(a.ApiPathPrefix, apiHandler)
+	if !config.DisableObservability {
+		wrappedHandler = observability.HTTPMiddleware(wrappedHandler)
+	}
 	router.Methods("GET", "POST", "DELETE", "OPTIONS").PathPrefix(fmt.Sprintf("%s/", a.ApiPathPrefix)).Handler(wrappedHandler)
 
 	log.Infof("       api:  you can access API using %s", a.GetAPIPath())
@@ -118,25 +177,10 @@ func (a *agentkitServerApp) SetupRouters(router *mux.Router, config *apps.RunCon
 	return nil
 }
 
-func (a *agentkitServerApp) GetApiConfig() *apps.ApiConfig {
+func (a *AgentkitServerApp) GetApiConfig() *apps.ApiConfig {
 	return a.ApiConfig
 }
 
-func (a *agentkitServerApp) GetServerName() string {
+func (a *AgentkitServerApp) GetServerName() string {
 	return serverName
-}
-
-func corsWithArgs(frontendAddress string) func(next http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Access-Control-Allow-Origin", frontendAddress)
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
-			if r.Method == "OPTIONS" {
-				w.WriteHeader(http.StatusOK)
-				return
-			}
-			next.ServeHTTP(w, r)
-		})
-	}
 }

--- a/apps/agentkit_server_app/app_test.go
+++ b/apps/agentkit_server_app/app_test.go
@@ -1,0 +1,309 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agentkit_server_app
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/volcengine/veadk-go/apps"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/session"
+)
+
+var _ apps.BasicApp = (*AgentkitServerApp)(nil)
+
+func TestAgentkitServerRunHTTPBlackbox(t *testing.T) {
+	rootAgent, err := agent.New(agent.Config{Name: "http_blackbox_agent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := reservePort(t)
+	apiConfig := apps.DefaultApiConfig().
+		SetHost("127.0.0.1").
+		SetPort(port).
+		SetApiPathPrefix("/api").
+		SetSimpleAPIEnabled(false).
+		SetWebUIEnabled(false).
+		SetMaxRequestBodyBytes(8).
+		SetCORS(&apps.CORSConfig{
+			AllowedOrigins: []string{"https://sandbox.example"},
+			AllowedMethods: []string{http.MethodGet, http.MethodPost},
+			AllowedHeaders: []string{"X-Request-ID"},
+		})
+	app := NewAgentkitServerApp(
+		apiConfig,
+		WithMiddleware(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.Header().Set("X-Extension-Middleware", "enabled")
+				next.ServeHTTP(writer, request)
+			})
+		}),
+		WithRouteSetup(func(router *mux.Router, _ *apps.RunConfig) error {
+			router.HandleFunc("/healthz", func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(http.StatusNoContent)
+			}).Methods(http.MethodGet)
+			router.HandleFunc("/upload", func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(http.StatusCreated)
+			}).Methods(http.MethodPost)
+			return nil
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- app.Run(ctx, &apps.RunConfig{
+			AgentLoader:          agent.NewSingleLoader(rootAgent),
+			SessionService:       session.InMemoryService(),
+			DisableObservability: true,
+		})
+	}()
+	waitForTCP(t, apiConfig.ListenAddress())
+
+	request, err := http.NewRequest(http.MethodGet, apiConfig.GetWebUrl()+"/healthz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Origin", "https://sandbox.example")
+	response, err := (&http.Client{Timeout: time.Second}).Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if got, want := response.StatusCode, http.StatusNoContent; got != want {
+		t.Fatalf("health status = %d, want %d", got, want)
+	}
+	if got, want := response.Header.Get("X-Extension-Middleware"), "enabled"; got != want {
+		t.Fatalf("middleware header = %q, want %q", got, want)
+	}
+	if got, want := response.Header.Get("Access-Control-Allow-Origin"), "https://sandbox.example"; got != want {
+		t.Fatalf("CORS origin = %q, want %q", got, want)
+	}
+
+	largeRequest, err := http.NewRequest(http.MethodPost, apiConfig.GetWebUrl()+"/upload", strings.NewReader("123456789"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	largeResponse, err := (&http.Client{Timeout: time.Second}).Do(largeRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = largeResponse.Body.Close()
+	if got, want := largeResponse.StatusCode, http.StatusRequestEntityTooLarge; got != want {
+		t.Fatalf("large request status = %d, want %d", got, want)
+	}
+
+	cancel()
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run() did not stop after parent cancellation")
+	}
+}
+
+func TestSetupRoutersSupportsExtensionsAndStableMiddlewareOrder(t *testing.T) {
+	rootAgent, err := agent.New(agent.Config{
+		Name:        "extension_agent",
+		Description: "tests server extensions",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var mu sync.Mutex
+	var order []string
+	record := func(value string) {
+		mu.Lock()
+		defer mu.Unlock()
+		order = append(order, value)
+	}
+	middleware := func(name string) mux.MiddlewareFunc {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				record(name + "-before")
+				next.ServeHTTP(writer, request)
+				record(name + "-after")
+			})
+		}
+	}
+
+	apiConfig := apps.DefaultApiConfig().
+		SetHost("127.0.0.1").
+		SetPort(8024).
+		SetApiPathPrefix("/api").
+		SetSimpleAPIEnabled(false).
+		SetWebUIEnabled(false)
+	app := NewAgentkitServerApp(
+		apiConfig,
+		WithMiddleware(middleware("first"), nil, middleware("second")),
+		WithRouteSetup(nil),
+		WithRouteSetup(func(router *mux.Router, _ *apps.RunConfig) error {
+			router.HandleFunc("/api/custom", func(writer http.ResponseWriter, _ *http.Request) {
+				record("handler")
+				writer.WriteHeader(218)
+			}).Methods(http.MethodGet)
+			return nil
+		}),
+	)
+
+	router := mux.NewRouter()
+	err = app.SetupRouters(router, &apps.RunConfig{
+		AgentLoader:          agent.NewSingleLoader(rootAgent),
+		SessionService:       session.InMemoryService(),
+		DisableObservability: true,
+	})
+	if err != nil {
+		t.Fatalf("SetupRouters() error = %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/custom", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if got, want := response.Code, 218; got != want {
+		t.Fatalf("custom route status = %d, want %d: %s", got, want, response.Body.String())
+	}
+	wantOrder := []string{"first-before", "second-before", "handler", "second-after", "first-after"}
+	if !slices.Equal(order, wantOrder) {
+		t.Fatalf("middleware order = %v, want %v", order, wantOrder)
+	}
+
+	invokeRequest := httptest.NewRequest(http.MethodPost, "/invoke", strings.NewReader(`{"prompt":"hello"}`))
+	invokeResponse := httptest.NewRecorder()
+	router.ServeHTTP(invokeResponse, invokeRequest)
+	if got, want := invokeResponse.Code, http.StatusNotFound; got != want {
+		t.Fatalf("disabled simple API status = %d, want %d", got, want)
+	}
+
+	webUIRequest := httptest.NewRequest(http.MethodGet, "/dev-ui/", nil)
+	webUIResponse := httptest.NewRecorder()
+	router.ServeHTTP(webUIResponse, webUIRequest)
+	if got, want := webUIResponse.Code, http.StatusNotFound; got != want {
+		t.Fatalf("disabled WebUI status = %d, want %d", got, want)
+	}
+}
+
+func TestSetupRoutersKeepsBuiltInRoutesAheadOfExtensions(t *testing.T) {
+	rootAgent, err := agent.New(agent.Config{Name: "priority_agent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewAgentkitServerApp(
+		apps.DefaultApiConfig().SetSimpleAPIEnabled(false).SetWebUIEnabled(false),
+		WithRouteSetup(func(router *mux.Router, _ *apps.RunConfig) error {
+			router.HandleFunc("/", func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(299)
+			})
+			return nil
+		}),
+	)
+	router := mux.NewRouter()
+	if err := app.SetupRouters(router, &apps.RunConfig{
+		AgentLoader:          agent.NewSingleLoader(rootAgent),
+		SessionService:       session.InMemoryService(),
+		DisableObservability: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"jsonrpc":"2.0","id":"1","method":"unknown"}`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code == 299 {
+		t.Fatal("custom route overrode the built-in A2A route")
+	}
+}
+
+func TestSetupRoutersRedactsExtensionFailure(t *testing.T) {
+	rootAgent, err := agent.New(agent.Config{Name: "failure_agent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sensitive := errors.New("private route configuration token")
+	app := NewAgentkitServerApp(
+		apps.DefaultApiConfig().SetSimpleAPIEnabled(false).SetWebUIEnabled(false),
+		WithRouteSetup(func(*mux.Router, *apps.RunConfig) error { return sensitive }),
+	)
+	err = app.SetupRouters(mux.NewRouter(), &apps.RunConfig{
+		AgentLoader:          agent.NewSingleLoader(rootAgent),
+		SessionService:       session.InMemoryService(),
+		DisableObservability: true,
+	})
+	if err == nil {
+		t.Fatal("SetupRouters() error = nil")
+	}
+	if strings.Contains(err.Error(), sensitive.Error()) {
+		t.Fatalf("SetupRouters() leaked extension error: %v", err)
+	}
+	if !errors.Is(err, sensitive) {
+		t.Fatalf("errors.Is(SetupRouters(), sensitive) = false: %v", err)
+	}
+}
+
+func TestSetupRoutersRejectsMissingDependencies(t *testing.T) {
+	app := NewAgentkitServerApp(nil)
+	if err := app.SetupRouters(nil, &apps.RunConfig{}); err == nil {
+		t.Fatal("SetupRouters(nil router) error = nil")
+	}
+	if err := app.SetupRouters(mux.NewRouter(), nil); err == nil {
+		t.Fatal("SetupRouters(nil config) error = nil")
+	}
+	if err := app.SetupRouters(mux.NewRouter(), &apps.RunConfig{}); err == nil {
+		t.Fatal("SetupRouters(missing agent) error = nil")
+	}
+}
+
+func reservePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func waitForTCP(t *testing.T, address string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		connection, err := net.DialTimeout("tcp", address, 20*time.Millisecond)
+		if err == nil {
+			_ = connection.Close()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server did not listen on %s: %v", address, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/apps/basic_app.go
+++ b/apps/basic_app.go
@@ -18,9 +18,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
-	"os"
 	"os/signal"
+	"slices"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -46,6 +49,10 @@ type RunConfig struct {
 	A2AOptions       []a2asrv.RequestHandlerOption
 	PluginConfig     runner.PluginConfig
 	TelemetryOptions []telemetry.Option
+	// DisableObservability skips VeADK's default observability plugin and
+	// shutdown hook. Embedders that manage telemetry themselves can use this to
+	// avoid installing or shutting down global providers.
+	DisableObservability bool
 }
 
 func (cfg *RunConfig) AppendObservability() {
@@ -69,12 +76,61 @@ func (cfg *RunConfig) AppendObservability() {
 }
 
 type ApiConfig struct {
-	Port            int
-	WriteTimeout    time.Duration
-	ReadTimeout     time.Duration
-	IdleTimeout     time.Duration
-	SEEWriteTimeout time.Duration
-	ApiPathPrefix   string
+	Host                string
+	Port                int
+	WriteTimeout        time.Duration
+	ReadTimeout         time.Duration
+	IdleTimeout         time.Duration
+	SEEWriteTimeout     time.Duration
+	ShutdownTimeout     time.Duration
+	ApiPathPrefix       string
+	DisableSimpleAPI    bool
+	DisableWebUI        bool
+	MaxRequestBodyBytes int64
+	DisableCORS         bool
+	CORS                CORSConfig
+}
+
+// CORSConfig controls cross-origin requests for every route served by an app.
+// An empty AllowedOrigins list allows only the app's own public address.
+type CORSConfig struct {
+	AllowedOrigins   []string
+	AllowedMethods   []string
+	AllowedHeaders   []string
+	ExposedHeaders   []string
+	AllowCredentials bool
+	MaxAge           time.Duration
+}
+
+// SetupError reports a router or configuration setup failure without putting
+// the underlying error text in logs or user-facing process output. Callers can
+// still inspect the cause with errors.Is/errors.As.
+type SetupError struct {
+	Operation string
+	err       error
+}
+
+func (e *SetupError) Error() string {
+	if e == nil || strings.TrimSpace(e.Operation) == "" {
+		return "server setup failed"
+	}
+	return e.Operation + " failed"
+}
+
+func (e *SetupError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+// NewSetupError creates a setup error whose public text does not include the
+// potentially sensitive cause.
+func NewSetupError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &SetupError{Operation: operation, err: err}
 }
 
 type BasicApp interface {
@@ -86,13 +142,24 @@ type BasicApp interface {
 
 func DefaultApiConfig() *ApiConfig {
 	return &ApiConfig{
+		Host:            "",
 		Port:            8000,
 		WriteTimeout:    time.Second * 60,
 		ReadTimeout:     time.Second * 60,
 		IdleTimeout:     time.Second * 120,
 		SEEWriteTimeout: time.Second * 300,
+		ShutdownTimeout: time.Second * 30,
 		ApiPathPrefix:   "", // set /api same as ADK-Go
+		CORS: CORSConfig{
+			AllowedMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions},
+			AllowedHeaders: []string{"Content-Type", "Authorization"},
+		},
 	}
+}
+
+func (a *ApiConfig) SetHost(host string) *ApiConfig {
+	a.Host = host
+	return a
 }
 
 func (a *ApiConfig) SetPort(port int) *ApiConfig {
@@ -115,75 +182,329 @@ func (a *ApiConfig) SetIdleTimeout(t int64) *ApiConfig {
 	return a
 }
 
+// SetSEEWriteTimeout is retained for compatibility. Use SetSSEWriteTimeout.
 func (a *ApiConfig) SetSEEWriteTimeout(t int64) *ApiConfig {
+	return a.SetSSEWriteTimeout(t)
+}
+
+// SetSSEWriteTimeout configures the ADK REST streaming response timeout.
+func (a *ApiConfig) SetSSEWriteTimeout(t int64) *ApiConfig {
 	a.SEEWriteTimeout = time.Second * time.Duration(t)
 	return a
 }
 
+func (a *ApiConfig) SetShutdownTimeout(t int64) *ApiConfig {
+	a.ShutdownTimeout = time.Second * time.Duration(t)
+	return a
+}
+
 func (a *ApiConfig) SetApiPathPrefix(p string) *ApiConfig {
-	a.ApiPathPrefix = p
+	a.ApiPathPrefix = normalizePathPrefix(p)
+	return a
+}
+
+func (a *ApiConfig) SetSimpleAPIEnabled(enabled bool) *ApiConfig {
+	a.DisableSimpleAPI = !enabled
+	return a
+}
+
+func (a *ApiConfig) SetWebUIEnabled(enabled bool) *ApiConfig {
+	a.DisableWebUI = !enabled
+	return a
+}
+
+// IsSimpleAPIEnabled reports whether the built-in /invoke and /health routes
+// are enabled. The zero value preserves the historical enabled behavior.
+func (a *ApiConfig) IsSimpleAPIEnabled() bool {
+	return !a.DisableSimpleAPI
+}
+
+// IsWebUIEnabled reports whether ADK WebUI routes are enabled. The zero value
+// preserves the historical enabled behavior.
+func (a *ApiConfig) IsWebUIEnabled() bool {
+	return !a.DisableWebUI
+}
+
+func (a *ApiConfig) SetMaxRequestBodyBytes(limit int64) *ApiConfig {
+	a.MaxRequestBodyBytes = limit
+	return a
+}
+
+func (a *ApiConfig) SetCORS(config *CORSConfig) *ApiConfig {
+	if config == nil {
+		a.DisableCORS = true
+		a.CORS = CORSConfig{}
+		return a
+	}
+	a.DisableCORS = false
+	a.CORS = *config
 	return a
 }
 
 func (a *ApiConfig) GetWebUrl() string {
-	return fmt.Sprintf("http://localhost:%d", a.Port)
+	host := a.Host
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "localhost"
+	}
+	return "http://" + net.JoinHostPort(host, strconv.Itoa(a.Port))
 }
 
 func (a *ApiConfig) GetAPIPath() string {
-	return fmt.Sprintf("http://localhost:%d%s", a.Port, a.ApiPathPrefix)
+	return a.GetWebUrl() + normalizePathPrefix(a.ApiPathPrefix)
+}
+
+func (a *ApiConfig) ListenAddress() string {
+	return net.JoinHostPort(a.Host, strconv.Itoa(a.Port))
+}
+
+func normalizePathPrefix(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" || path == "/" {
+		return ""
+	}
+	return "/" + strings.Trim(path, "/")
+}
+
+func (a *ApiConfig) validate() error {
+	if a.Port < 0 || a.Port > 65535 {
+		return errors.New("port is outside the valid range")
+	}
+	if a.WriteTimeout < 0 || a.ReadTimeout < 0 || a.IdleTimeout < 0 || a.SEEWriteTimeout < 0 || a.ShutdownTimeout < 0 {
+		return errors.New("HTTP timeout must not be negative")
+	}
+	if a.MaxRequestBodyBytes < 0 {
+		return errors.New("request body limit must not be negative")
+	}
+	if !a.DisableCORS && a.CORS.AllowCredentials && slices.Contains(a.CORS.AllowedOrigins, "*") {
+		return errors.New("credentialed CORS cannot allow every origin")
+	}
+	if !a.DisableCORS && a.CORS.MaxAge < 0 {
+		return errors.New("CORS max age must not be negative")
+	}
+	return nil
 }
 
 func Run(ctx context.Context, config *RunConfig, app BasicApp) error {
+	if ctx == nil {
+		return errors.New("context is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if config == nil {
+		return errors.New("run config is required")
+	}
+	if app == nil || app.GetApiConfig() == nil {
+		return errors.New("app with API config is required")
+	}
+	apiConfig := app.GetApiConfig()
+	if err := apiConfig.validate(); err != nil {
+		return NewSetupError("validate server configuration", err)
+	}
+	runCtx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	listener, err := net.Listen("tcp", apiConfig.ListenAddress())
+	if err != nil {
+		return fmt.Errorf("%s listen failed: %w", app.GetServerName(), err)
+	}
+	defer listener.Close()
+
 	router := web.BuildBaseRouter()
 
 	if config.SessionService == nil {
 		config.SessionService = session.InMemoryService()
 	}
 
-	config.AppendObservability()
-
-	defer func() {
-		err := observability.Shutdown(ctx)
-		if err != nil {
-			log.Errorf("shutting down observability error: %s", err.Error())
-			return
-		}
-		log.Info("observability stopped")
-	}()
+	if !config.DisableObservability {
+		config.AppendObservability()
+		defer shutdownObservability()
+	}
 
 	log.Infof("Web servers starts on %s", app.GetApiConfig().GetWebUrl())
-	err := app.SetupRouters(router, config)
+	err = app.SetupRouters(router, config)
 	if err != nil {
-		return fmt.Errorf("setup %s routers failed: %w", app.GetServerName(), err)
+		return NewSetupError("setup "+app.GetServerName()+" routers", err)
 	}
 
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(quit)
-
-	srv := http.Server{
-		Addr:         fmt.Sprintf(":%v", fmt.Sprint(app.GetApiConfig().Port)),
-		WriteTimeout: app.GetApiConfig().WriteTimeout,
-		ReadTimeout:  app.GetApiConfig().ReadTimeout,
-		IdleTimeout:  app.GetApiConfig().IdleTimeout,
-		Handler:      router,
+	handler := buildServerHandler(router, apiConfig, app.GetServerName())
+	srv := &http.Server{
+		Addr:         apiConfig.ListenAddress(),
+		WriteTimeout: apiConfig.WriteTimeout,
+		ReadTimeout:  apiConfig.ReadTimeout,
+		IdleTimeout:  apiConfig.IdleTimeout,
+		Handler:      handler,
+		BaseContext: func(net.Listener) context.Context {
+			// Preserve parent values without canceling active requests before the
+			// configured graceful-shutdown window has elapsed.
+			return context.WithoutCancel(ctx)
+		},
 	}
 
+	serverErr := make(chan error, 1)
 	go func() {
-		<-quit
-		log.Infof("Received shutdown signal, gracefully stopping %s...", app.GetServerName())
-		shutdownCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-		if err := srv.Shutdown(shutdownCtx); err != nil {
-			log.Errorf("Server shutdown failed: %v", err)
-		}
+		serverErr <- srv.Serve(listener)
 	}()
 
-	err = srv.ListenAndServe()
-	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		return fmt.Errorf("%s failed: %v", app.GetServerName(), err)
+	select {
+	case err = <-serverErr:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("%s failed: %w", app.GetServerName(), err)
+		}
+	case <-runCtx.Done():
+		log.Infof("Received shutdown request, gracefully stopping %s...", app.GetServerName())
+		if err := shutdownServer(srv, serverErr, apiConfig.ShutdownTimeout); err != nil {
+			return fmt.Errorf("shutdown %s failed: %w", app.GetServerName(), err)
+		}
 	}
 
 	log.Infof("%s stopped gracefully", app.GetServerName())
 	return nil
+}
+
+func shutdownObservability() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := observability.Shutdown(ctx); err != nil {
+		log.Errorf("shutting down observability failed")
+		return
+	}
+	log.Info("observability stopped")
+}
+
+func shutdownServer(server *http.Server, serverErr <-chan error, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	shutdownErr := server.Shutdown(shutdownCtx)
+	if shutdownErr != nil {
+		closeErr := server.Close()
+		serveErr := waitForServer(serverErr, 2*time.Second)
+		return errors.Join(shutdownErr, closeErr, serveErr)
+	}
+	return waitForServer(serverErr, 2*time.Second)
+}
+
+func waitForServer(serverErr <-chan error, timeout time.Duration) error {
+	select {
+	case err := <-serverErr:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	case <-time.After(timeout):
+		return errors.New("server did not stop after close")
+	}
+}
+
+func buildServerHandler(next http.Handler, config *ApiConfig, serverName string) http.Handler {
+	handler := next
+	if config.MaxRequestBodyBytes > 0 {
+		handler = requestBodyLimitMiddleware(config.MaxRequestBodyBytes, handler)
+	}
+	if !config.DisableCORS {
+		handler = corsMiddleware(config, handler)
+	}
+	return recoveryMiddleware(serverName, handler)
+}
+
+func recoveryMiddleware(serverName string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		defer func() {
+			if recover() != nil {
+				log.Errorf("%s recovered a panic while serving a request", serverName)
+				http.Error(writer, "internal server error", http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(writer, request)
+	})
+}
+
+func requestBodyLimitMiddleware(limit int64, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.ContentLength > limit {
+			http.Error(writer, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		request.Body = http.MaxBytesReader(writer, request.Body, limit)
+		next.ServeHTTP(writer, request)
+	})
+}
+
+func corsMiddleware(apiConfig *ApiConfig, next http.Handler) http.Handler {
+	config := &apiConfig.CORS
+	allowedOrigins := slices.Clone(config.AllowedOrigins)
+	if len(allowedOrigins) == 0 {
+		allowedOrigins = []string{apiConfig.GetWebUrl()}
+	}
+	allowedMethods := slices.Clone(config.AllowedMethods)
+	if len(allowedMethods) == 0 {
+		allowedMethods = []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions}
+	}
+	allowedHeaders := slices.Clone(config.AllowedHeaders)
+	if len(allowedHeaders) == 0 {
+		allowedHeaders = []string{"Content-Type", "Authorization"}
+	}
+	exposedHeaders := slices.Clone(config.ExposedHeaders)
+	allowCredentials := config.AllowCredentials
+	maxAge := config.MaxAge
+
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		origin := request.Header.Get("Origin")
+		if origin == "" {
+			next.ServeHTTP(writer, request)
+			return
+		}
+		writer.Header().Add("Vary", "Origin")
+		if !containsFold(allowedOrigins, origin) && !slices.Contains(allowedOrigins, "*") {
+			http.Error(writer, "origin not allowed", http.StatusForbidden)
+			return
+		}
+		allowOrigin := origin
+		if slices.Contains(allowedOrigins, "*") {
+			allowOrigin = "*"
+		}
+		writer.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+		writer.Header().Set("Access-Control-Allow-Methods", strings.Join(allowedMethods, ", "))
+		writer.Header().Set("Access-Control-Allow-Headers", strings.Join(allowedHeaders, ", "))
+		if len(exposedHeaders) > 0 {
+			writer.Header().Set("Access-Control-Expose-Headers", strings.Join(exposedHeaders, ", "))
+		}
+		if allowCredentials {
+			writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		}
+		if maxAge > 0 {
+			writer.Header().Set("Access-Control-Max-Age", strconv.FormatInt(int64(maxAge/time.Second), 10))
+		}
+		if request.Method == http.MethodOptions && request.Header.Get("Access-Control-Request-Method") != "" {
+			writer.Header().Add("Vary", "Access-Control-Request-Method")
+			writer.Header().Add("Vary", "Access-Control-Request-Headers")
+			if !containsFold(allowedMethods, request.Header.Get("Access-Control-Request-Method")) {
+				http.Error(writer, "method not allowed", http.StatusForbidden)
+				return
+			}
+			for _, requested := range strings.Split(request.Header.Get("Access-Control-Request-Headers"), ",") {
+				requested = strings.TrimSpace(requested)
+				if requested != "" && !containsFold(allowedHeaders, requested) {
+					http.Error(writer, "header not allowed", http.StatusForbidden)
+					return
+				}
+			}
+			writer.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(writer, request)
+	})
+}
+
+func containsFold(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, target) {
+			return true
+		}
+	}
+	return false
 }

--- a/apps/basic_app_test.go
+++ b/apps/basic_app_test.go
@@ -35,9 +35,6 @@ import (
 )
 
 func TestRunRejectsInvalidInputs(t *testing.T) {
-	if err := Run(nil, &RunConfig{}, nil); err == nil {
-		t.Fatal("Run(nil context) error = nil")
-	}
 	if err := Run(context.Background(), nil, nil); err == nil {
 		t.Fatal("Run(nil config) error = nil")
 	}

--- a/apps/basic_app_test.go
+++ b/apps/basic_app_test.go
@@ -1,0 +1,457 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+func TestRunRejectsInvalidInputs(t *testing.T) {
+	if err := Run(nil, &RunConfig{}, nil); err == nil {
+		t.Fatal("Run(nil context) error = nil")
+	}
+	if err := Run(context.Background(), nil, nil); err == nil {
+		t.Fatal("Run(nil config) error = nil")
+	}
+	if err := Run(context.Background(), &RunConfig{}, nil); err == nil {
+		t.Fatal("Run(nil app) error = nil")
+	}
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := Run(canceled, &RunConfig{}, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run(canceled context) error = %v, want context.Canceled", err)
+	}
+}
+
+func TestAPIConfigAddressesAndFlags(t *testing.T) {
+	zeroValue := &ApiConfig{}
+	if !zeroValue.IsSimpleAPIEnabled() || !zeroValue.IsWebUIEnabled() || zeroValue.DisableCORS {
+		t.Fatal("ApiConfig zero value did not preserve historically enabled HTTP features")
+	}
+
+	config := DefaultApiConfig().
+		SetHost("127.0.0.1").
+		SetPort(8024).
+		SetWriteTimeout(11).
+		SetReadTimeout(12).
+		SetIdleTimeout(13).
+		SetSEEWriteTimeout(14).
+		SetShutdownTimeout(15).
+		SetApiPathPrefix("/api/").
+		SetSimpleAPIEnabled(false).
+		SetWebUIEnabled(false).
+		SetMaxRequestBodyBytes(1024)
+
+	if got, want := config.ListenAddress(), "127.0.0.1:8024"; got != want {
+		t.Fatalf("ListenAddress() = %q, want %q", got, want)
+	}
+	if got, want := config.GetWebUrl(), "http://127.0.0.1:8024"; got != want {
+		t.Fatalf("GetWebUrl() = %q, want %q", got, want)
+	}
+	if got, want := config.GetAPIPath(), "http://127.0.0.1:8024/api"; got != want {
+		t.Fatalf("GetAPIPath() = %q, want %q", got, want)
+	}
+	if config.IsSimpleAPIEnabled() || config.IsWebUIEnabled() {
+		t.Fatal("simple API or WebUI remained enabled")
+	}
+	if got, want := config.MaxRequestBodyBytes, int64(1024); got != want {
+		t.Fatalf("MaxRequestBodyBytes = %d, want %d", got, want)
+	}
+	if config.WriteTimeout != 11*time.Second || config.ReadTimeout != 12*time.Second ||
+		config.IdleTimeout != 13*time.Second || config.SEEWriteTimeout != 14*time.Second ||
+		config.ShutdownTimeout != 15*time.Second {
+		t.Fatalf("configured timeouts were not preserved: %+v", config)
+	}
+
+	config.SetHost("0.0.0.0")
+	if got, want := config.GetWebUrl(), "http://localhost:8024"; got != want {
+		t.Fatalf("wildcard GetWebUrl() = %q, want %q", got, want)
+	}
+	config.SetCORS(nil)
+	if !config.DisableCORS {
+		t.Fatal("SetCORS(nil) did not disable CORS")
+	}
+}
+
+type lifecycleTestApp struct {
+	config *ApiConfig
+	setup  func(*mux.Router) error
+}
+
+func (a *lifecycleTestApp) Run(ctx context.Context, config *RunConfig) error {
+	return Run(ctx, config, a)
+}
+
+func (a *lifecycleTestApp) SetupRouters(router *mux.Router, _ *RunConfig) error {
+	if a.setup != nil {
+		return a.setup(router)
+	}
+	return nil
+}
+
+func (a *lifecycleTestApp) GetApiConfig() *ApiConfig { return a.config }
+func (a *lifecycleTestApp) GetServerName() string    { return "lifecycle-test" }
+
+func TestRunReportsPortConflict(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	setupCalled := false
+	app := &lifecycleTestApp{
+		config: DefaultApiConfig().SetHost("127.0.0.1").SetPort(port),
+		setup: func(*mux.Router) error {
+			setupCalled = true
+			return nil
+		},
+	}
+	err = app.Run(context.Background(), &RunConfig{DisableObservability: true})
+	if err == nil || !strings.Contains(err.Error(), "listen failed") {
+		t.Fatalf("Run() error = %v, want listen failure", err)
+	}
+	if setupCalled {
+		t.Fatal("router setup ran before detecting the port conflict")
+	}
+}
+
+func TestRunGracefulShutdownWaitsForActiveRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	app := newNetworkTestApp(t, func(router *mux.Router) error {
+		router.HandleFunc("/slow", func(writer http.ResponseWriter, _ *http.Request) {
+			startedOnce.Do(func() { close(started) })
+			<-release
+			writer.WriteHeader(http.StatusNoContent)
+		})
+		return nil
+	})
+	app.config.ShutdownTimeout = time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- app.Run(ctx, &RunConfig{DisableObservability: true}) }()
+	waitForTCP(t, app.config.ListenAddress())
+
+	requestErr := make(chan error, 1)
+	go func() {
+		response, err := (&http.Client{Timeout: 2 * time.Second}).Get(app.config.GetWebUrl() + "/slow")
+		if err == nil {
+			_ = response.Body.Close()
+		}
+		requestErr <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow request did not start")
+	}
+
+	cancel()
+	select {
+	case err := <-runErr:
+		t.Fatalf("Run() returned before active request completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	if err := <-runErr; err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if err := <-requestErr; err != nil {
+		t.Fatalf("slow request error = %v", err)
+	}
+}
+
+func TestRunForcesCloseAfterShutdownTimeout(t *testing.T) {
+	started := make(chan struct{})
+	stopped := make(chan struct{})
+	var startedOnce sync.Once
+	var stoppedOnce sync.Once
+	app := newNetworkTestApp(t, func(router *mux.Router) error {
+		router.HandleFunc("/block", func(_ http.ResponseWriter, request *http.Request) {
+			startedOnce.Do(func() { close(started) })
+			<-request.Context().Done()
+			stoppedOnce.Do(func() { close(stopped) })
+		})
+		return nil
+	})
+	app.config.ShutdownTimeout = 20 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- app.Run(ctx, &RunConfig{DisableObservability: true}) }()
+	waitForTCP(t, app.config.ListenAddress())
+	go func() {
+		response, err := (&http.Client{Timeout: 2 * time.Second}).Get(app.config.GetWebUrl() + "/block")
+		if err == nil {
+			_ = response.Body.Close()
+		}
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocking request did not start")
+	}
+
+	cancel()
+	select {
+	case err := <-runErr:
+		if err == nil || !strings.Contains(err.Error(), "shutdown lifecycle-test failed") {
+			t.Fatalf("Run() error = %v, want shutdown timeout", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run() did not return after forced close")
+	}
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("forced close did not cancel the active request")
+	}
+}
+
+func TestServerHandlerCORSBodyLimitAndRecovery(t *testing.T) {
+	router := mux.NewRouter()
+	router.HandleFunc("/echo", func(writer http.ResponseWriter, request *http.Request) {
+		body, err := io.ReadAll(request.Body)
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			http.Error(writer, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		_, _ = writer.Write(body)
+	}).Methods(http.MethodPost)
+	router.HandleFunc("/panic", func(http.ResponseWriter, *http.Request) {
+		panic("sensitive-panic-value")
+	}).Methods(http.MethodGet)
+
+	config := DefaultApiConfig().SetMaxRequestBodyBytes(4).SetCORS(&CORSConfig{
+		AllowedOrigins:   []string{"https://allowed.example"},
+		AllowedMethods:   []string{http.MethodPost},
+		AllowedHeaders:   []string{"X-Request-ID"},
+		ExposedHeaders:   []string{"X-Response-ID"},
+		AllowCredentials: true,
+		MaxAge:           time.Minute,
+	})
+	handler := buildServerHandler(router, config, "test-server")
+
+	preflight := httptest.NewRequest(http.MethodOptions, "/echo", nil)
+	preflight.Header.Set("Origin", "https://allowed.example")
+	preflight.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	preflight.Header.Set("Access-Control-Request-Headers", "x-request-id")
+	preflightResponse := httptest.NewRecorder()
+	handler.ServeHTTP(preflightResponse, preflight)
+	if got, want := preflightResponse.Code, http.StatusNoContent; got != want {
+		t.Fatalf("preflight status = %d, want %d: %s", got, want, preflightResponse.Body.String())
+	}
+	if got, want := preflightResponse.Header().Get("Access-Control-Allow-Origin"), "https://allowed.example"; got != want {
+		t.Fatalf("allow origin = %q, want %q", got, want)
+	}
+	if got, want := preflightResponse.Header().Get("Access-Control-Allow-Credentials"), "true"; got != want {
+		t.Fatalf("allow credentials = %q, want %q", got, want)
+	}
+
+	disallowed := httptest.NewRequest(http.MethodPost, "/echo", strings.NewReader("ok"))
+	disallowed.Header.Set("Origin", "https://denied.example")
+	disallowedResponse := httptest.NewRecorder()
+	handler.ServeHTTP(disallowedResponse, disallowed)
+	if got, want := disallowedResponse.Code, http.StatusForbidden; got != want {
+		t.Fatalf("disallowed origin status = %d, want %d", got, want)
+	}
+
+	large := httptest.NewRequest(http.MethodPost, "/echo", strings.NewReader("12345"))
+	largeResponse := httptest.NewRecorder()
+	handler.ServeHTTP(largeResponse, large)
+	if got, want := largeResponse.Code, http.StatusRequestEntityTooLarge; got != want {
+		t.Fatalf("large body status = %d, want %d", got, want)
+	}
+
+	chunked := httptest.NewRequest(http.MethodPost, "/echo", strings.NewReader("12345"))
+	chunked.ContentLength = -1
+	chunked.TransferEncoding = []string{"chunked"}
+	chunkedResponse := httptest.NewRecorder()
+	handler.ServeHTTP(chunkedResponse, chunked)
+	if got, want := chunkedResponse.Code, http.StatusRequestEntityTooLarge; got != want {
+		t.Fatalf("chunked large body status = %d, want %d", got, want)
+	}
+
+	panicRequest := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	panicResponse := httptest.NewRecorder()
+	handler.ServeHTTP(panicResponse, panicRequest)
+	if got, want := panicResponse.Code, http.StatusInternalServerError; got != want {
+		t.Fatalf("panic status = %d, want %d", got, want)
+	}
+	if strings.Contains(panicResponse.Body.String(), "sensitive-panic-value") {
+		t.Fatalf("panic response leaked the recovered value: %q", panicResponse.Body.String())
+	}
+}
+
+func TestRunRedactsSetupAndConfigurationErrors(t *testing.T) {
+	sensitive := errors.New("credential secret must not be exposed")
+	app := &lifecycleTestApp{
+		config: DefaultApiConfig(),
+		setup:  func(*mux.Router) error { return sensitive },
+	}
+	err := app.Run(context.Background(), &RunConfig{DisableObservability: true})
+	if err == nil {
+		t.Fatal("Run() error = nil")
+	}
+	if strings.Contains(err.Error(), sensitive.Error()) {
+		t.Fatalf("Run() leaked setup error: %v", err)
+	}
+	if !errors.Is(err, sensitive) {
+		t.Fatalf("errors.Is(Run(), sensitive) = false: %v", err)
+	}
+
+	invalid := &lifecycleTestApp{config: DefaultApiConfig().SetCORS(&CORSConfig{
+		AllowedOrigins:   []string{"*"},
+		AllowCredentials: true,
+	})}
+	err = invalid.Run(context.Background(), &RunConfig{DisableObservability: true})
+	if err == nil || err.Error() != "validate server configuration failed" {
+		t.Fatalf("invalid CORS error = %v", err)
+	}
+}
+
+func TestRunHandlesRepeatedSIGTERMInRealProcess(t *testing.T) {
+	port := reservePort(t)
+	command := exec.Command(os.Args[0], "-test.run=^TestServerProcessHelper$")
+	command.Env = []string{
+		"VEADK_SERVER_PROCESS_HELPER=1",
+		"VEADK_SERVER_PROCESS_PORT=" + strconv.Itoa(port),
+	}
+	var output bytes.Buffer
+	command.Stdout = &output
+	command.Stderr = &output
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if command.ProcessState == nil {
+			_ = command.Process.Kill()
+			_, _ = command.Process.Wait()
+		}
+	}()
+
+	address := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	waitForTCP(t, address)
+	response, err := (&http.Client{Timeout: time.Second}).Get("http://" + address + "/block")
+	if err != nil {
+		t.Fatalf("start blocking request: %v; process output: %s", err, output.String())
+	}
+	_ = response.Body.Close()
+
+	if err := command.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("first SIGTERM: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if err := command.Process.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("second SIGTERM: %v", err)
+	}
+
+	waitErr := make(chan error, 1)
+	go func() { waitErr <- command.Wait() }()
+	select {
+	case err := <-waitErr:
+		if err != nil {
+			t.Fatalf("server process error = %v; output: %s", err, output.String())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("server process did not stop after SIGTERM; output: %s", output.String())
+	}
+}
+
+func TestServerProcessHelper(t *testing.T) {
+	if os.Getenv("VEADK_SERVER_PROCESS_HELPER") != "1" {
+		return
+	}
+	port, err := strconv.Atoi(os.Getenv("VEADK_SERVER_PROCESS_PORT"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := &lifecycleTestApp{
+		config: DefaultApiConfig().SetHost("127.0.0.1").SetPort(port),
+		setup: func(router *mux.Router) error {
+			router.HandleFunc("/block", func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(http.StatusOK)
+				if flusher, ok := writer.(http.Flusher); ok {
+					flusher.Flush()
+				}
+				time.Sleep(150 * time.Millisecond)
+			})
+			return nil
+		},
+	}
+	app.config.ShutdownTimeout = time.Second
+	if err := app.Run(context.Background(), &RunConfig{DisableObservability: true}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newNetworkTestApp(t *testing.T, setup func(*mux.Router) error) *lifecycleTestApp {
+	t.Helper()
+	return &lifecycleTestApp{
+		config: DefaultApiConfig().SetHost("127.0.0.1").SetPort(reservePort(t)),
+		setup:  setup,
+	}
+}
+
+func reservePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func waitForTCP(t *testing.T, address string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		connection, err := net.DialTimeout("tcp", address, 20*time.Millisecond)
+		if err == nil {
+			_ = connection.Close()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server did not listen on %s: %v", address, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/apps/simple_app/app.go
+++ b/apps/simple_app/app.go
@@ -110,7 +110,7 @@ type Response struct {
 func (a *agentkitSimpleApp) newInvokeHandler() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req Request
-		ctx := context.Background()
+		ctx := r.Context()
 
 		body, err := io.ReadAll(r.Body)
 		defer func() {


### PR DESCRIPTION
## Summary

- add configurable bind host, HTTP/SSE/shutdown timeouts, request body limits, and CORS policy while preserving zero-value compatibility
- make parent context and SIGINT/SIGTERM drive bounded graceful shutdown with forced close, synchronous listen errors, panic recovery, and redacted setup failures
- export AgentkitServerApp extension options for ordered middleware and custom routes, with switches for the simple API and WebUI
- propagate the incoming HTTP request context into simple agent invocation

## Validation

- target apps tests passed 10 consecutive runs
- target apps race tests passed
- repository tests passed with required Mockey gcflags, excluding the configs package whose tests create a working-directory .env file
- repository vet passed with the same configs exclusion
- real test-process HTTP coverage includes custom routes, middleware, CORS, request limits, parent cancellation, repeated SIGTERM, graceful drain, and forced close

## Scope

This branch is based directly on upstream/main and does not depend on PR #81. A2A public routing and Agent Card changes remain out of scope for the next A2A contracts PR.