### PR TITLE
feat(a2a): add public routing, streaming, and task contracts

### DIFF
--- a/apps/a2a_app/app.go
+++ b/apps/a2a_app/app.go
@@ -16,7 +16,9 @@ package a2a_app
 
 import (
 	"context"
-	"net/url"
+	"encoding/json"
+	"errors"
+	"net/http"
 
 	"github.com/volcengine/veadk-go/log"
 
@@ -30,13 +32,12 @@ import (
 )
 
 const (
-	serverName = "agentkit a2a server"
-	apiPath    = "/"
+	serverName          = "agentkit a2a server"
+	legacyAgentCardPath = "/.well-known/agent.json"
 )
 
 type agentkitA2AServerApp struct {
 	*apps.ApiConfig
-	a2aAgentUrl string
 }
 
 func (a *agentkitA2AServerApp) Run(ctx context.Context, config *apps.RunConfig) error {
@@ -44,24 +45,34 @@ func (a *agentkitA2AServerApp) Run(ctx context.Context, config *apps.RunConfig) 
 }
 
 func (a *agentkitA2AServerApp) SetupRouters(router *mux.Router, config *apps.RunConfig) error {
-	publicURL, err := url.JoinPath(a.a2aAgentUrl, apiPath)
-	if err != nil {
-		return err
+	if router == nil {
+		return errors.New("router is required")
 	}
-
+	if config == nil || config.AgentLoader == nil || config.AgentLoader.RootAgent() == nil {
+		return errors.New("agent loader with a root agent is required")
+	}
 	rootAgent := config.AgentLoader.RootAgent()
 	agentCard := &a2acore.AgentCard{
 		Name:                              rootAgent.Name(),
 		Description:                       rootAgent.Description(),
 		DefaultInputModes:                 []string{"text/plain"},
 		DefaultOutputModes:                []string{"text/plain"},
-		URL:                               publicURL,
+		URL:                               a.GetA2APublicURL(),
 		PreferredTransport:                a2acore.TransportProtocolJSONRPC,
 		Skills:                            adka2a.BuildAgentSkills(rootAgent),
 		Capabilities:                      a2acore.AgentCapabilities{Streaming: true},
 		SupportsAuthenticatedExtendedCard: false,
 	}
-	router.Handle(a2asrv.WellKnownAgentCardPath, a2asrv.NewStaticAgentCardHandler(agentCard))
+	cardHandler := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requestCard := *agentCard
+		requestCard.URL = a.ResolveAgentCardURL(request)
+		writer.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(writer).Encode(&requestCard); err != nil {
+			log.Errorf("failed to encode A2A Agent Card")
+		}
+	})
+	router.Handle(a2asrv.WellKnownAgentCardPath, cardHandler).Methods(http.MethodGet)
+	router.Handle(legacyAgentCardPath, cardHandler).Methods(http.MethodGet)
 
 	agent := config.AgentLoader.RootAgent()
 	executor := adka2a.NewExecutor(adka2a.ExecutorConfig{
@@ -75,10 +86,10 @@ func (a *agentkitA2AServerApp) SetupRouters(router *mux.Router, config *apps.Run
 		},
 	})
 	reqHandler := a2asrv.NewHandler(executor, config.A2AOptions...)
-	router.Handle(apiPath, a2asrv.NewJSONRPCHandler(reqHandler))
+	router.Handle(a.GetA2APath(), a2asrv.NewJSONRPCHandler(reqHandler)).Methods(http.MethodPost)
 
 	a2aLauncher := a2a.NewLauncher()
-	a2aLauncher.UserMessage(a.GetWebUrl()+apiPath, log.Println)
+	a2aLauncher.UserMessage(a.GetA2APublicURL(), log.Println)
 
 	return nil
 }
@@ -92,8 +103,10 @@ func (a *agentkitA2AServerApp) GetServerName() string {
 }
 
 func NewAgentkitA2AServerApp(config *apps.ApiConfig) apps.BasicApp {
+	if config == nil {
+		config = apps.DefaultApiConfig()
+	}
 	return &agentkitA2AServerApp{
-		ApiConfig:   config,
-		a2aAgentUrl: config.GetWebUrl(),
+		ApiConfig: config,
 	}
 }

--- a/apps/a2a_app/app_test.go
+++ b/apps/a2a_app/app_test.go
@@ -1,0 +1,885 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package a2a_app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"iter"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/a2aclient"
+	"github.com/a2aproject/a2a-go/a2asrv"
+	"github.com/gorilla/mux"
+	"github.com/volcengine/veadk-go/apps"
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/session"
+	"google.golang.org/genai"
+)
+
+func TestAgentCardsUseExplicitPublicRoutingAndIgnoreUntrustedHeaders(t *testing.T) {
+	rootAgent := newContractAgent(t, func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+		return singleResponse("ok")
+	})
+	config := apps.DefaultApiConfig().
+		SetPublicURL("https://agents.example/sandbox").
+		SetA2APath("/internal/a2a").
+		SetA2APublicPath("/public/a2a").
+		SetSimpleAPIEnabled(false).
+		SetWebUIEnabled(false)
+	router := setupRouter(t, rootAgent, session.InMemoryService(), config)
+
+	var cards []a2a.AgentCard
+	for _, path := range []string{a2asrv.WellKnownAgentCardPath, legacyAgentCardPath} {
+		request := httptest.NewRequest(http.MethodGet, path, nil)
+		request.Host = "attacker.invalid"
+		request.Header.Set("Forwarded", `for=192.0.2.1;proto=http;host="attacker.invalid"`)
+		request.Header.Set("X-Forwarded-Proto", "http")
+		request.Header.Set("X-Forwarded-Host", "attacker.invalid")
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+		if got, want := response.Code, http.StatusOK; got != want {
+			t.Fatalf("GET %s status = %d, want %d: %s", path, got, want, response.Body.String())
+		}
+		if got, want := response.Header().Get("Content-Type"), "application/json"; got != want {
+			t.Fatalf("GET %s Content-Type = %q, want %q", path, got, want)
+		}
+		var card a2a.AgentCard
+		if err := decodeJSON(response, &card); err != nil {
+			t.Fatalf("decode %s: %v", path, err)
+		}
+		cards = append(cards, card)
+	}
+
+	for i, card := range cards {
+		if got, want := card.URL, "https://agents.example/sandbox/public/a2a"; got != want {
+			t.Fatalf("card[%d].URL = %q, want %q", i, got, want)
+		}
+		if !card.Capabilities.Streaming {
+			t.Fatalf("card[%d] does not declare verified streaming support", i)
+		}
+		if card.Name != rootAgent.Name() || card.Description != rootAgent.Description() {
+			t.Fatalf("card[%d] identity = %q/%q", i, card.Name, card.Description)
+		}
+	}
+
+	publicRequest := httptest.NewRequest(http.MethodPost, "/public/a2a", strings.NewReader(`{}`))
+	publicResponse := httptest.NewRecorder()
+	router.ServeHTTP(publicResponse, publicRequest)
+	if got, want := publicResponse.Code, http.StatusNotFound; got != want {
+		t.Fatalf("public path status = %d, want %d", got, want)
+	}
+
+	internalRequest := httptest.NewRequest(http.MethodPost, "/internal/a2a", strings.NewReader(`{"jsonrpc":"2.0","id":"1","method":"unknown"}`))
+	internalResponse := httptest.NewRecorder()
+	router.ServeHTTP(internalResponse, internalRequest)
+	if got, want := internalResponse.Code, http.StatusOK; got != want {
+		t.Fatalf("internal path status = %d, want %d: %s", got, want, internalResponse.Body.String())
+	}
+}
+
+func TestSetupRoutersRejectsMissingHostDependencies(t *testing.T) {
+	app := NewAgentkitA2AServerApp(nil)
+	if err := app.SetupRouters(nil, &apps.RunConfig{}); err == nil {
+		t.Fatal("SetupRouters(nil router) error = nil")
+	}
+	if err := app.SetupRouters(mux.NewRouter(), nil); err == nil {
+		t.Fatal("SetupRouters(nil config) error = nil")
+	}
+	if err := app.SetupRouters(mux.NewRouter(), &apps.RunConfig{}); err == nil {
+		t.Fatal("SetupRouters(missing agent) error = nil")
+	}
+}
+
+func TestAgentCardForwardedURLIsExplicitOptIn(t *testing.T) {
+	rootAgent := newContractAgent(t, func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+		return singleResponse("ok")
+	})
+	config := apps.DefaultApiConfig().
+		SetPublicURL("https://configured.example/base").
+		SetA2APublicPath("/edge/a2a").
+		SetAgentCardURLResolver(apps.ForwardedAgentCardURL)
+	router := setupRouter(t, rootAgent, session.InMemoryService(), config)
+
+	request := httptest.NewRequest(http.MethodGet, a2asrv.WellKnownAgentCardPath, nil)
+	request.Host = "internal:8024"
+	request.Header.Set("Forwarded", `for=192.0.2.1;proto=https;host="gateway.example:8443"`)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	var card a2a.AgentCard
+	if err := decodeJSON(response, &card); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := card.URL, "https://gateway.example:8443/edge/a2a"; got != want {
+		t.Fatalf("card.URL = %q, want %q", got, want)
+	}
+
+	request = httptest.NewRequest(http.MethodGet, a2asrv.WellKnownAgentCardPath, nil)
+	request.Host = "bad host"
+	request.Header.Set("Forwarded", `proto=javascript;host="user@gateway.example"`)
+	response = httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if err := decodeJSON(response, &card); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := card.URL, "https://configured.example/base/edge/a2a"; got != want {
+		t.Fatalf("invalid forwarded card.URL = %q, want fallback %q", got, want)
+	}
+}
+
+func TestSendPollFailureMetadataHistoryAndSessionIsolation(t *testing.T) {
+	sessionService := session.InMemoryService()
+	rootAgent := newContractAgent(t, func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+		prompt := contentText(ctx.UserContent())
+		if strings.HasPrefix(prompt, "fail:") {
+			return func(yield func(*session.Event, error) bool) {
+				yield(nil, errors.New("expected agent failure"))
+			}
+		}
+		return singleResponse("result:" + prompt)
+	})
+	metadataCapture := &metadataCaptureInterceptor{}
+	_, client := setupHTTPServerWithOptions(
+		t,
+		rootAgent,
+		sessionService,
+		apps.DefaultApiConfig().SetA2APath("/rpc"),
+		a2asrv.WithRequestContextInterceptor(metadataCapture),
+	)
+
+	const sessionCount = 8
+	type result struct {
+		contextID string
+		task      *a2a.Task
+		err       error
+	}
+	results := make(chan result, sessionCount)
+	for i := range sessionCount {
+		contextID := fmt.Sprintf("session-%02d", i)
+		go func() {
+			message := a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "prompt:" + contextID})
+			message.ContextID = contextID
+			historyLength := 20
+			initial, err := client.SendMessage(t.Context(), &a2a.MessageSendParams{
+				Message:  message,
+				Metadata: map[string]any{"request_id": contextID},
+				Config:   &a2a.MessageSendConfig{HistoryLength: &historyLength},
+			})
+			if err != nil {
+				results <- result{contextID: contextID, err: err}
+				return
+			}
+			if initial.TaskInfo().TaskID == "" {
+				results <- result{contextID: contextID, err: errors.New("message/send returned an empty task id")}
+				return
+			}
+			task, err := waitForTask(t.Context(), client, initial.TaskInfo().TaskID)
+			results <- result{contextID: contextID, task: task, err: err}
+		}()
+	}
+
+	for range sessionCount {
+		result := <-results
+		if result.err != nil {
+			t.Fatalf("%s: %v", result.contextID, result.err)
+		}
+		if result.task.Status.State != a2a.TaskStateCompleted {
+			t.Fatalf("%s state = %q, want completed", result.contextID, result.task.Status.State)
+		}
+		if result.task.ContextID != result.contextID {
+			t.Fatalf("%s task context = %q", result.contextID, result.task.ContextID)
+		}
+		if got, want := taskText(result.task), "result:prompt:"+result.contextID; !strings.Contains(got, want) {
+			t.Fatalf("%s artifact text = %q, want %q", result.contextID, got, want)
+		}
+		if got, want := result.task.Metadata["adk_session_id"], any(result.contextID); got != want {
+			t.Fatalf("%s metadata session = %v, want %v", result.contextID, got, want)
+		}
+		if !metadataCapture.saw(result.contextID) {
+			t.Fatalf("%s request metadata did not reach the A2A request context", result.contextID)
+		}
+
+		historyLength := 20
+		withHistory, err := client.GetTask(t.Context(), &a2a.TaskQueryParams{ID: result.task.ID, HistoryLength: &historyLength})
+		if err != nil {
+			t.Fatalf("%s tasks/get with history: %v", result.contextID, err)
+		}
+		if len(withHistory.History) != 1 || messageText(withHistory.History[0]) != "prompt:"+result.contextID {
+			t.Fatalf("%s history = %#v, want its input message", result.contextID, withHistory.History)
+		}
+
+		historyLength = 0
+		withoutHistory, err := client.GetTask(t.Context(), &a2a.TaskQueryParams{ID: result.task.ID, HistoryLength: &historyLength})
+		if err != nil {
+			t.Fatalf("%s tasks/get without history: %v", result.contextID, err)
+		}
+		if len(withoutHistory.History) != 0 {
+			t.Fatalf("%s history length = %d, want 0", result.contextID, len(withoutHistory.History))
+		}
+
+		sessions, err := sessionService.List(t.Context(), &session.ListRequest{
+			AppName: rootAgent.Name(),
+			UserID:  "A2A_USER_" + result.contextID,
+		})
+		if err != nil {
+			t.Fatalf("%s list session: %v", result.contextID, err)
+		}
+		if len(sessions.Sessions) != 1 || sessions.Sessions[0].ID() != result.contextID {
+			t.Fatalf("%s sessions = %#v, want one isolated session", result.contextID, sessions.Sessions)
+		}
+		storedSession, err := sessionService.Get(t.Context(), &session.GetRequest{
+			AppName:   rootAgent.Name(),
+			UserID:    "A2A_USER_" + result.contextID,
+			SessionID: result.contextID,
+		})
+		if err != nil {
+			t.Fatalf("%s get session: %v", result.contextID, err)
+		}
+		if sessionEventsText(storedSession.Session) != "prompt:"+result.contextID+"|result:prompt:"+result.contextID {
+			t.Fatalf("%s session events leaked or were incomplete: %q", result.contextID, sessionEventsText(storedSession.Session))
+		}
+	}
+
+	failureMessage := a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "fail:now"})
+	failureMessage.ContextID = "failed-session"
+	failureResult, err := client.SendMessage(t.Context(), &a2a.MessageSendParams{Message: failureMessage})
+	if err != nil {
+		t.Fatalf("send failed task: %v", err)
+	}
+	failedTask, err := waitForTask(t.Context(), client, failureResult.TaskInfo().TaskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := failedTask.Status.State, a2a.TaskStateFailed; got != want {
+		t.Fatalf("failed task state = %q, want %q", got, want)
+	}
+	if failedTask.Status.Message == nil || !strings.Contains(messageText(failedTask.Status.Message), "expected agent failure") {
+		t.Fatalf("failed task message = %#v", failedTask.Status.Message)
+	}
+
+	emptyMessage := a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: ""})
+	emptyMessage.ContextID = "empty-text-session"
+	emptyResult, err := client.SendMessage(t.Context(), &a2a.MessageSendParams{Message: emptyMessage})
+	if err != nil {
+		t.Fatalf("send empty text message: %v", err)
+	}
+	emptyTask, err := waitForTask(t.Context(), client, emptyResult.TaskInfo().TaskID)
+	if err != nil || emptyTask.Status.State != a2a.TaskStateCompleted {
+		t.Fatalf("empty text task = %#v, err = %v", emptyTask, err)
+	}
+
+	_, err = client.GetTask(t.Context(), &a2a.TaskQueryParams{ID: "missing-task"})
+	if !errors.Is(err, a2a.ErrTaskNotFound) {
+		t.Fatalf("unknown tasks/get error = %v, want ErrTaskNotFound", err)
+	}
+}
+
+func TestStreamingSSEEventOrderArtifactsTerminalAndDisconnect(t *testing.T) {
+	rootAgent := newContractAgent(t, func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			for _, event := range []*session.Event{
+				responseEvent("hel", true),
+				responseEvent("lo", true),
+				responseEvent("hello", false),
+			} {
+				if !yield(event, nil) {
+					return
+				}
+			}
+		}
+	})
+	_, client := setupHTTPServer(t, rootAgent, session.InMemoryService(), apps.DefaultApiConfig().SetA2APath("/stream"))
+
+	message := a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "stream"})
+	var events []a2a.Event
+	for event, err := range client.SendStreamingMessage(t.Context(), &a2a.MessageSendParams{Message: message}) {
+		if err != nil {
+			t.Fatalf("message/stream error = %v", err)
+		}
+		events = append(events, event)
+	}
+	if len(events) < 7 {
+		t.Fatalf("message/stream returned %d events, want submitted/working/artifacts/final", len(events))
+	}
+	initial, ok := events[0].(*a2a.Task)
+	if !ok || initial.Status.State != a2a.TaskStateSubmitted {
+		t.Fatalf("events[0] = %#v, want submitted task", events[0])
+	}
+	working, ok := events[1].(*a2a.TaskStatusUpdateEvent)
+	if !ok || working.Status.State != a2a.TaskStateWorking || working.Final {
+		t.Fatalf("events[1] = %#v, want non-final working status", events[1])
+	}
+	var artifactTexts []string
+	var sawLastChunk bool
+	for _, event := range events[2 : len(events)-1] {
+		if event.TaskInfo() != initial.TaskInfo() {
+			t.Fatalf("event task info = %#v, want %#v", event.TaskInfo(), initial.TaskInfo())
+		}
+		if artifact, ok := event.(*a2a.TaskArtifactUpdateEvent); ok {
+			artifactTexts = append(artifactTexts, partsText(artifact.Artifact.Parts))
+			sawLastChunk = sawLastChunk || artifact.LastChunk
+		}
+	}
+	if got := strings.Join(artifactTexts, "|"); !strings.Contains(got, "hel") || !strings.Contains(got, "lo") || !strings.Contains(got, "hello") {
+		t.Fatalf("stream artifact texts = %q", got)
+	}
+	if !sawLastChunk {
+		t.Fatal("stream did not contain a final artifact chunk")
+	}
+	terminal, ok := events[len(events)-1].(*a2a.TaskStatusUpdateEvent)
+	if !ok || terminal.Status.State != a2a.TaskStateCompleted || !terminal.Final {
+		t.Fatalf("last event = %#v, want final completed status", events[len(events)-1])
+	}
+
+	errorAgent := newContractAgent(t, func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			yield(nil, errors.New("stream execution failed"))
+		}
+	})
+	_, errorClient := setupHTTPServer(t, errorAgent, session.InMemoryService(), apps.DefaultApiConfig().SetA2APath("/stream"))
+	var errorEvents []a2a.Event
+	for event, err := range errorClient.SendStreamingMessage(t.Context(), &a2a.MessageSendParams{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "fail stream"}),
+	}) {
+		if err != nil {
+			t.Fatalf("failed task must be represented as an A2A event: %v", err)
+		}
+		errorEvents = append(errorEvents, event)
+	}
+	if len(errorEvents) == 0 {
+		t.Fatal("failed stream returned no A2A events")
+	}
+	failedTerminal, ok := errorEvents[len(errorEvents)-1].(*a2a.TaskStatusUpdateEvent)
+	if !ok || failedTerminal.Status.State != a2a.TaskStateFailed || !failedTerminal.Final {
+		t.Fatalf("failed stream terminal event = %#v", errorEvents[len(errorEvents)-1])
+	}
+	if failedTerminal.Status.Message == nil || !strings.Contains(messageText(failedTerminal.Status.Message), "stream execution failed") {
+		t.Fatalf("failed stream message = %#v", failedTerminal.Status.Message)
+	}
+
+	releaseDisconnectedTask := make(chan struct{})
+	var releaseDisconnectedTaskOnce sync.Once
+	defer releaseDisconnectedTaskOnce.Do(func() { close(releaseDisconnectedTask) })
+	disconnectedTaskFinished := make(chan struct{})
+	disconnectAgent := newContractAgent(t, func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			defer close(disconnectedTaskFinished)
+			if !yield(responseEvent("first-chunk", true), nil) {
+				return
+			}
+			<-releaseDisconnectedTask
+			yield(responseEvent("after-disconnect", false), nil)
+		}
+	})
+	_, disconnectClient := setupHTTPServer(t, disconnectAgent, session.InMemoryService(), apps.DefaultApiConfig().SetA2APath("/stream"))
+	disconnectCtx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var disconnectedTaskID a2a.TaskID
+	for event, err := range disconnectClient.SendStreamingMessage(disconnectCtx, &a2a.MessageSendParams{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "disconnect"}),
+	}) {
+		if err != nil {
+			t.Fatalf("disconnect stream error = %v", err)
+		}
+		if task, ok := event.(*a2a.Task); ok {
+			disconnectedTaskID = task.ID
+		}
+		if _, ok := event.(*a2a.TaskArtifactUpdateEvent); ok {
+			cancel()
+			break
+		}
+	}
+	if disconnectedTaskID == "" {
+		t.Fatal("disconnected stream did not return a task id")
+	}
+	releaseDisconnectedTaskOnce.Do(func() { close(releaseDisconnectedTask) })
+	select {
+	case <-disconnectedTaskFinished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("task did not finish after the SSE client disconnected")
+	}
+	disconnectedTask, err := waitForTask(t.Context(), disconnectClient, disconnectedTaskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disconnectedTask.Status.State != a2a.TaskStateCompleted || !strings.Contains(taskText(disconnectedTask), "after-disconnect") {
+		t.Fatalf("task after stream disconnect = %#v", disconnectedTask)
+	}
+}
+
+func TestCancelStopsRunningAgentIsIdempotentAndRejectsTerminalOrUnknown(t *testing.T) {
+	started := make(chan struct{})
+	stopped := make(chan struct{})
+	var startedOnce sync.Once
+	var stoppedOnce sync.Once
+	rootAgent := newContractAgent(t, func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+		return func(yield func(*session.Event, error) bool) {
+			startedOnce.Do(func() { close(started) })
+			<-ctx.Done()
+			stoppedOnce.Do(func() { close(stopped) })
+			yield(nil, ctx.Err())
+		}
+	})
+	_, client := setupHTTPServer(t, rootAgent, session.InMemoryService(), apps.DefaultApiConfig().SetA2APath("/cancel"))
+
+	result, err := client.SendMessage(t.Context(), &a2a.MessageSendParams{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "wait"}),
+	})
+	if err != nil {
+		t.Fatalf("message/send: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("agent did not start")
+	}
+	canceled, err := client.CancelTask(t.Context(), &a2a.TaskIDParams{ID: result.TaskInfo().TaskID})
+	if err != nil {
+		t.Fatalf("tasks/cancel: %v", err)
+	}
+	if got, want := canceled.Status.State, a2a.TaskStateCanceled; got != want {
+		t.Fatalf("canceled state = %q, want %q", got, want)
+	}
+	second, err := client.CancelTask(t.Context(), &a2a.TaskIDParams{ID: result.TaskInfo().TaskID})
+	if err != nil {
+		t.Fatalf("second tasks/cancel: %v", err)
+	}
+	if second.Status.State != a2a.TaskStateCanceled {
+		t.Fatalf("second tasks/cancel state = %q", second.Status.State)
+	}
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("running agent did not observe cancellation")
+	}
+	persisted, err := client.GetTask(t.Context(), &a2a.TaskQueryParams{ID: result.TaskInfo().TaskID})
+	if err != nil || persisted.Status.State != a2a.TaskStateCanceled {
+		t.Fatalf("persisted canceled task = %#v, err = %v", persisted, err)
+	}
+
+	quickAgent := newContractAgent(t, func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+		return singleResponse("done")
+	})
+	_, quickClient := setupHTTPServer(t, quickAgent, session.InMemoryService(), apps.DefaultApiConfig().SetA2APath("/cancel"))
+	quickResult, err := quickClient.SendMessage(t.Context(), &a2a.MessageSendParams{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "finish"}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	completed, err := waitForTask(t.Context(), quickClient, quickResult.TaskInfo().TaskID)
+	if err != nil || completed.Status.State != a2a.TaskStateCompleted {
+		t.Fatalf("completed task = %#v, err = %v", completed, err)
+	}
+	_, err = quickClient.CancelTask(t.Context(), &a2a.TaskIDParams{ID: completed.ID})
+	if !errors.Is(err, a2a.ErrTaskNotCancelable) {
+		t.Fatalf("cancel completed error = %v, want ErrTaskNotCancelable", err)
+	}
+	_, err = quickClient.CancelTask(t.Context(), &a2a.TaskIDParams{ID: "missing-task"})
+	if !errors.Is(err, a2a.ErrTaskNotFound) {
+		t.Fatalf("cancel unknown error = %v, want ErrTaskNotFound", err)
+	}
+}
+
+func TestTaskPollingPreservesRejectedCanceledAndUnknownStates(t *testing.T) {
+	store := &fixedTaskStore{tasks: make(map[a2a.TaskID]*a2a.Task)}
+	for _, state := range []a2a.TaskState{a2a.TaskStateRejected, a2a.TaskStateCanceled, a2a.TaskStateUnknown} {
+		id := a2a.TaskID("task-" + state)
+		store.tasks[id] = &a2a.Task{ID: id, ContextID: "context-" + string(state), Status: a2a.TaskStatus{State: state}}
+	}
+	rootAgent := newContractAgent(t, func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+		return singleResponse("unused")
+	})
+	_, client := setupHTTPServerWithOptions(
+		t,
+		rootAgent,
+		session.InMemoryService(),
+		apps.DefaultApiConfig().SetA2APath("/states"),
+		a2asrv.WithTaskStore(store),
+	)
+
+	for _, want := range []a2a.TaskState{a2a.TaskStateRejected, a2a.TaskStateCanceled, a2a.TaskStateUnknown} {
+		task, err := client.GetTask(t.Context(), &a2a.TaskQueryParams{ID: a2a.TaskID("task-" + want)})
+		if err != nil {
+			t.Fatalf("tasks/get %s: %v", want, err)
+		}
+		if task.Status.State != want {
+			t.Fatalf("tasks/get state = %q, want %q", task.Status.State, want)
+		}
+	}
+}
+
+func TestCancelCompleteRaceAlwaysLeavesATerminalTask(t *testing.T) {
+	for i := range 12 {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			release := make(chan struct{})
+			started := make(chan struct{})
+			finished := make(chan struct{})
+			rootAgent := newContractAgent(t, func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+				return func(yield func(*session.Event, error) bool) {
+					defer close(finished)
+					close(started)
+					select {
+					case <-ctx.Done():
+						return
+					case <-release:
+						yield(responseEvent("won completion race", false), nil)
+					}
+				}
+			})
+			_, client := setupHTTPServer(t, rootAgent, session.InMemoryService(), apps.DefaultApiConfig().SetA2APath("/race"))
+			result, err := client.SendMessage(t.Context(), &a2a.MessageSendParams{
+				Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "race"}),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("agent did not start")
+			}
+
+			startRace := make(chan struct{})
+			cancelErr := make(chan error, 1)
+			go func() {
+				<-startRace
+				_, err := client.CancelTask(t.Context(), &a2a.TaskIDParams{ID: result.TaskInfo().TaskID})
+				cancelErr <- err
+			}()
+			go func() {
+				<-startRace
+				close(release)
+			}()
+			close(startRace)
+
+			err = <-cancelErr
+			if err != nil && !errors.Is(err, a2a.ErrTaskNotCancelable) {
+				t.Fatalf("cancel race error = %v", err)
+			}
+			select {
+			case <-finished:
+			case <-time.After(time.Second):
+				t.Fatal("racing agent did not stop")
+			}
+			task, err := waitForTask(t.Context(), client, result.TaskInfo().TaskID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if task.Status.State != a2a.TaskStateCompleted && task.Status.State != a2a.TaskStateCanceled {
+				t.Fatalf("cancel/complete race state = %q", task.Status.State)
+			}
+		})
+	}
+}
+
+func TestA2AContractThroughRealServerRun(t *testing.T) {
+	rootAgent := newContractAgent(t, func(ctx agent.InvocationContext) iter.Seq2[*session.Event, error] {
+		return singleResponse("network-result")
+	})
+	port := reservePort(t)
+	config := apps.DefaultApiConfig().
+		SetHost("127.0.0.1").
+		SetPort(port).
+		SetA2APath("/internal/a2a").
+		SetA2APublicPath("/public/a2a").
+		SetPublicURL("https://agent.example/sandbox").
+		SetSimpleAPIEnabled(false).
+		SetWebUIEnabled(false)
+	app := NewAgentkitA2AServerApp(config)
+	runCtx, cancelRun := context.WithCancel(t.Context())
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- app.Run(runCtx, &apps.RunConfig{
+			AgentLoader:          agent.NewSingleLoader(rootAgent),
+			SessionService:       session.InMemoryService(),
+			DisableObservability: true,
+		})
+	}()
+	waitForServer(t, config.ListenAddress())
+
+	cardResponse, err := (&http.Client{Timeout: time.Second}).Get(config.GetWebUrl() + a2asrv.WellKnownAgentCardPath)
+	if err != nil {
+		cancelRun()
+		t.Fatalf("get Agent Card: %v", err)
+	}
+	defer func() {
+		if err := cardResponse.Body.Close(); err != nil {
+			t.Errorf("close Agent Card response: %v", err)
+		}
+	}()
+	var card a2a.AgentCard
+	if err := json.NewDecoder(cardResponse.Body).Decode(&card); err != nil {
+		cancelRun()
+		t.Fatalf("decode Agent Card: %v", err)
+	}
+	if got, want := card.URL, "https://agent.example/sandbox/public/a2a"; got != want {
+		cancelRun()
+		t.Fatalf("card URL = %q, want %q", got, want)
+	}
+
+	clientCard := &a2a.AgentCard{
+		URL:                config.GetWebUrl() + config.GetA2APath(),
+		PreferredTransport: a2a.TransportProtocolJSONRPC,
+		Capabilities:       a2a.AgentCapabilities{Streaming: true},
+	}
+	client, err := a2aclient.NewFromCard(t.Context(), clientCard, a2aclient.WithConfig(a2aclient.Config{Polling: true}))
+	if err != nil {
+		cancelRun()
+		t.Fatal(err)
+	}
+	result, err := client.SendMessage(t.Context(), &a2a.MessageSendParams{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "network"}),
+	})
+	if err != nil {
+		cancelRun()
+		t.Fatal(err)
+	}
+	task, err := waitForTask(t.Context(), client, result.TaskInfo().TaskID)
+	if err != nil || task.Status.State != a2a.TaskStateCompleted || !strings.Contains(taskText(task), "network-result") {
+		cancelRun()
+		t.Fatalf("network task = %#v, err = %v", task, err)
+	}
+
+	cancelRun()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("app.Run(): %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("app.Run() did not stop")
+	}
+}
+
+func newContractAgent(t *testing.T, run func(agent.InvocationContext) iter.Seq2[*session.Event, error]) agent.Agent {
+	t.Helper()
+	result, err := agent.New(agent.Config{
+		Name:        "a2a_contract_agent",
+		Description: "Exercises A2A host contracts.",
+		Run:         run,
+	})
+	if err != nil {
+		t.Fatalf("agent.New(): %v", err)
+	}
+	return result
+}
+
+func setupRouter(t *testing.T, rootAgent agent.Agent, sessionService session.Service, config *apps.ApiConfig, options ...a2asrv.RequestHandlerOption) *mux.Router {
+	t.Helper()
+	router := mux.NewRouter()
+	app := NewAgentkitA2AServerApp(config)
+	if err := app.SetupRouters(router, &apps.RunConfig{
+		AgentLoader:          agent.NewSingleLoader(rootAgent),
+		SessionService:       sessionService,
+		A2AOptions:           options,
+		DisableObservability: true,
+	}); err != nil {
+		t.Fatalf("SetupRouters(): %v", err)
+	}
+	return router
+}
+
+func setupHTTPServer(t *testing.T, rootAgent agent.Agent, sessionService session.Service, config *apps.ApiConfig) (*httptest.Server, *a2aclient.Client) {
+	t.Helper()
+	return setupHTTPServerWithOptions(t, rootAgent, sessionService, config)
+}
+
+func setupHTTPServerWithOptions(t *testing.T, rootAgent agent.Agent, sessionService session.Service, config *apps.ApiConfig, options ...a2asrv.RequestHandlerOption) (*httptest.Server, *a2aclient.Client) {
+	t.Helper()
+	router := setupRouter(t, rootAgent, sessionService, config, options...)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	card := &a2a.AgentCard{
+		Name:               rootAgent.Name(),
+		URL:                server.URL + config.GetA2APath(),
+		PreferredTransport: a2a.TransportProtocolJSONRPC,
+		Capabilities:       a2a.AgentCapabilities{Streaming: true},
+	}
+	client, err := a2aclient.NewFromCard(
+		t.Context(),
+		card,
+		a2aclient.WithConfig(a2aclient.Config{Polling: true}),
+		a2aclient.WithJSONRPCTransport(&http.Client{Timeout: 2 * time.Second}),
+	)
+	if err != nil {
+		t.Fatalf("a2aclient.NewFromCard(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := client.Destroy(); err != nil {
+			t.Errorf("client.Destroy(): %v", err)
+		}
+	})
+	return server, client
+}
+
+func singleResponse(text string) iter.Seq2[*session.Event, error] {
+	return func(yield func(*session.Event, error) bool) {
+		yield(responseEvent(text, false), nil)
+	}
+}
+
+func responseEvent(text string, partial bool) *session.Event {
+	return &session.Event{LLMResponse: model.LLMResponse{
+		Content: genai.NewContentFromText(text, genai.RoleModel),
+		Partial: partial,
+	}}
+}
+
+func waitForTask(ctx context.Context, client *a2aclient.Client, id a2a.TaskID) (*a2a.Task, error) {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		task, err := client.GetTask(ctx, &a2a.TaskQueryParams{ID: id})
+		if err != nil {
+			return nil, err
+		}
+		if task.Status.State.Terminal() {
+			return task, nil
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return nil, fmt.Errorf("task %s did not reach a terminal state", id)
+}
+
+func taskText(task *a2a.Task) string {
+	var result []string
+	for _, artifact := range task.Artifacts {
+		if artifact != nil {
+			if text := partsText(artifact.Parts); text != "" {
+				result = append(result, text)
+			}
+		}
+	}
+	return strings.Join(result, "|")
+}
+
+func messageText(message *a2a.Message) string {
+	if message == nil {
+		return ""
+	}
+	return partsText(message.Parts)
+}
+
+func partsText(parts a2a.ContentParts) string {
+	var result []string
+	for _, part := range parts {
+		if text, ok := part.(a2a.TextPart); ok {
+			result = append(result, text.Text)
+		}
+	}
+	return strings.Join(result, "")
+}
+
+func contentText(content *genai.Content) string {
+	if content == nil {
+		return ""
+	}
+	var result strings.Builder
+	for _, part := range content.Parts {
+		result.WriteString(part.Text)
+	}
+	return result.String()
+}
+
+func sessionEventsText(value session.Session) string {
+	var result []string
+	for event := range value.Events().All() {
+		if event.Content != nil {
+			if text := contentText(event.Content); text != "" {
+				result = append(result, text)
+			}
+		}
+	}
+	return strings.Join(result, "|")
+}
+
+func decodeJSON(response *httptest.ResponseRecorder, target any) error {
+	return json.NewDecoder(response.Body).Decode(target)
+}
+
+func reservePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func waitForServer(t *testing.T, address string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		connection, err := net.DialTimeout("tcp", address, 20*time.Millisecond)
+		if err == nil {
+			_ = connection.Close()
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("server did not listen on %s", address)
+}
+
+type fixedTaskStore struct {
+	tasks map[a2a.TaskID]*a2a.Task
+}
+
+type metadataCaptureInterceptor struct {
+	seenIDs sync.Map
+}
+
+func (i *metadataCaptureInterceptor) Intercept(ctx context.Context, request *a2asrv.RequestContext) (context.Context, error) {
+	if requestID, ok := request.Metadata["request_id"].(string); ok {
+		i.seenIDs.Store(requestID, struct{}{})
+	}
+	return ctx, nil
+}
+
+func (i *metadataCaptureInterceptor) saw(requestID string) bool {
+	_, ok := i.seenIDs.Load(requestID)
+	return ok
+}
+
+func (s *fixedTaskStore) Save(context.Context, *a2a.Task, a2a.Event, *a2a.Task, a2a.TaskVersion) (a2a.TaskVersion, error) {
+	return a2a.TaskVersionMissing, errors.New("fixed task store is read-only")
+}
+
+func (s *fixedTaskStore) Get(_ context.Context, id a2a.TaskID) (*a2a.Task, a2a.TaskVersion, error) {
+	task, ok := s.tasks[id]
+	if !ok {
+		return nil, a2a.TaskVersionMissing, a2a.ErrTaskNotFound
+	}
+	copy := *task
+	return &copy, 1, nil
+}
+
+func (s *fixedTaskStore) List(context.Context, *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
+	return nil, errors.New("list is not supported by fixed task store")
+}

--- a/apps/a2a_config.go
+++ b/apps/a2a_config.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// AgentCardURLResolver resolves the externally reachable A2A endpoint for one
+// Agent Card request. Resolvers are an explicit trust boundary: the default is
+// nil and therefore ignores Host, Forwarded and X-Forwarded-* headers.
+type AgentCardURLResolver func(request *http.Request, config *ApiConfig) string
+
+// SetPublicURL sets the externally reachable base URL used by Agent Cards.
+// It may include a path prefix, for example https://example.test/sandbox.
+func (a *ApiConfig) SetPublicURL(publicURL string) *ApiConfig {
+	a.PublicURL = strings.TrimRight(strings.TrimSpace(publicURL), "/")
+	return a
+}
+
+// SetA2APath sets the internal HTTP route used by the A2A JSON-RPC handler.
+func (a *ApiConfig) SetA2APath(path string) *ApiConfig {
+	a.A2APath = normalizeRoutePath(path)
+	return a
+}
+
+// SetA2APublicPath sets the externally visible path advertised by Agent Cards.
+// An empty value makes it follow A2APath.
+func (a *ApiConfig) SetA2APublicPath(path string) *ApiConfig {
+	if strings.TrimSpace(path) == "" {
+		a.A2APublicPath = ""
+		return a
+	}
+	a.A2APublicPath = normalizeRoutePath(path)
+	return a
+}
+
+// SetAgentCardURLResolver opts into request-aware Agent Card URLs. Use
+// ForwardedAgentCardURL only behind a trusted reverse proxy which overwrites
+// client-supplied forwarding headers.
+func (a *ApiConfig) SetAgentCardURLResolver(resolver AgentCardURLResolver) *ApiConfig {
+	a.AgentCardURLResolver = resolver
+	return a
+}
+
+// GetA2APath returns the internal A2A JSON-RPC route.
+func (a *ApiConfig) GetA2APath() string {
+	return normalizeRoutePath(a.A2APath)
+}
+
+// GetA2APublicPath returns the path advertised to A2A clients.
+func (a *ApiConfig) GetA2APublicPath() string {
+	if strings.TrimSpace(a.A2APublicPath) != "" {
+		return normalizeRoutePath(a.A2APublicPath)
+	}
+	return a.GetA2APath()
+}
+
+// GetA2APublicURL returns the configured, request-independent Agent Card URL.
+func (a *ApiConfig) GetA2APublicURL() string {
+	baseURL := a.GetWebUrl()
+	if validPublicURL(a.PublicURL) {
+		baseURL = a.PublicURL
+	}
+	publicURL, err := url.JoinPath(baseURL, a.GetA2APublicPath())
+	if err != nil {
+		return baseURL
+	}
+	return publicURL
+}
+
+// ResolveAgentCardURL resolves an Agent Card URL and falls back to static
+// configuration if a custom resolver returns an invalid or empty URL.
+func (a *ApiConfig) ResolveAgentCardURL(request *http.Request) string {
+	if a.AgentCardURLResolver != nil {
+		resolved := strings.TrimSpace(a.AgentCardURLResolver(request, a))
+		if validPublicURL(resolved) {
+			return resolved
+		}
+	}
+	return a.GetA2APublicURL()
+}
+
+// ForwardedAgentCardURL resolves an Agent Card URL from standard Forwarded or
+// X-Forwarded-Proto/X-Forwarded-Host headers. It must only be enabled behind a
+// trusted proxy which removes client-supplied forwarding headers.
+func ForwardedAgentCardURL(request *http.Request, config *ApiConfig) string {
+	if request == nil || config == nil {
+		return ""
+	}
+
+	scheme := "http"
+	if request.TLS != nil {
+		scheme = "https"
+	} else if request.URL != nil && validPublicScheme(request.URL.Scheme) {
+		scheme = strings.ToLower(request.URL.Scheme)
+	}
+	host := request.Host
+	if host == "" && request.URL != nil {
+		host = request.URL.Host
+	}
+
+	forwardedScheme, forwardedHost := parseForwarded(request.Header.Get("Forwarded"))
+	if forwardedScheme != "" {
+		scheme = forwardedScheme
+	}
+	if forwardedHost != "" {
+		host = forwardedHost
+	}
+	if forwardedScheme == "" {
+		if candidate := firstHeaderValue(request.Header.Get("X-Forwarded-Proto")); validPublicScheme(candidate) {
+			scheme = strings.ToLower(candidate)
+		}
+	}
+	if forwardedHost == "" {
+		if candidate := firstHeaderValue(request.Header.Get("X-Forwarded-Host")); validPublicHost(candidate) {
+			host = candidate
+		}
+	}
+	if !validPublicScheme(scheme) || !validPublicHost(host) {
+		return ""
+	}
+
+	result := &url.URL{Scheme: scheme, Host: host, Path: config.GetA2APublicPath()}
+	return result.String()
+}
+
+func normalizeRoutePath(route string) string {
+	route = strings.TrimSpace(route)
+	if route == "" || route == "/" {
+		return "/"
+	}
+	return "/" + strings.Trim(route, "/")
+}
+
+func validPublicURL(value string) bool {
+	parsed, err := url.Parse(value)
+	return err == nil && parsed != nil && validPublicScheme(parsed.Scheme) &&
+		validPublicHost(parsed.Host) && parsed.User == nil && parsed.RawQuery == "" && parsed.Fragment == ""
+}
+
+func validPublicScheme(value string) bool {
+	return strings.EqualFold(value, "http") || strings.EqualFold(value, "https")
+}
+
+func validPublicHost(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.ContainsAny(value, "\\/?#@\r\n\t ") {
+		return false
+	}
+	parsed, err := url.Parse("http://" + value)
+	return err == nil && parsed.Host == value && parsed.Hostname() != "" && parsed.User == nil && parsed.Path == ""
+}
+
+func firstHeaderValue(value string) string {
+	return strings.TrimSpace(strings.SplitN(value, ",", 2)[0])
+}
+
+func parseForwarded(value string) (scheme, host string) {
+	first := firstHeaderValue(value)
+	for _, parameter := range strings.Split(first, ";") {
+		key, candidate, ok := strings.Cut(parameter, "=")
+		if !ok {
+			continue
+		}
+		candidate = strings.Trim(strings.TrimSpace(candidate), `"`)
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "proto":
+			if validPublicScheme(candidate) {
+				scheme = strings.ToLower(candidate)
+			}
+		case "host":
+			if validPublicHost(candidate) {
+				host = candidate
+			}
+		}
+	}
+	return scheme, host
+}

--- a/apps/basic_app.go
+++ b/apps/basic_app.go
@@ -76,19 +76,28 @@ func (cfg *RunConfig) AppendObservability() {
 }
 
 type ApiConfig struct {
-	Host                string
-	Port                int
-	WriteTimeout        time.Duration
-	ReadTimeout         time.Duration
-	IdleTimeout         time.Duration
-	SEEWriteTimeout     time.Duration
-	ShutdownTimeout     time.Duration
-	ApiPathPrefix       string
-	DisableSimpleAPI    bool
-	DisableWebUI        bool
-	MaxRequestBodyBytes int64
-	DisableCORS         bool
-	CORS                CORSConfig
+	Host string
+	Port int
+	// PublicURL is the externally reachable base URL advertised in Agent Cards.
+	// It is never inferred from request headers unless AgentCardURLResolver is set.
+	PublicURL       string
+	WriteTimeout    time.Duration
+	ReadTimeout     time.Duration
+	IdleTimeout     time.Duration
+	SEEWriteTimeout time.Duration
+	ShutdownTimeout time.Duration
+	ApiPathPrefix   string
+	// A2APath is the route mounted on this HTTP server. A2APublicPath is the
+	// externally visible route advertised in Agent Cards and may differ when a
+	// reverse proxy rewrites paths.
+	A2APath              string
+	A2APublicPath        string
+	AgentCardURLResolver AgentCardURLResolver
+	DisableSimpleAPI     bool
+	DisableWebUI         bool
+	MaxRequestBodyBytes  int64
+	DisableCORS          bool
+	CORS                 CORSConfig
 }
 
 // CORSConfig controls cross-origin requests for every route served by an app.
@@ -274,6 +283,15 @@ func (a *ApiConfig) validate() error {
 	}
 	if a.MaxRequestBodyBytes < 0 {
 		return errors.New("request body limit must not be negative")
+	}
+	if a.PublicURL != "" && !validPublicURL(a.PublicURL) {
+		return errors.New("public URL must be an absolute HTTP or HTTPS URL without user info, query, or fragment")
+	}
+	if a.A2APath != "" && !strings.HasPrefix(a.A2APath, "/") {
+		return errors.New("A2A path must be absolute")
+	}
+	if a.A2APublicPath != "" && !strings.HasPrefix(a.A2APublicPath, "/") {
+		return errors.New("A2A public path must be absolute")
 	}
 	if !a.DisableCORS && a.CORS.AllowCredentials && slices.Contains(a.CORS.AllowedOrigins, "*") {
 		return errors.New("credentialed CORS cannot allow every origin")

--- a/apps/basic_app_test.go
+++ b/apps/basic_app_test.go
@@ -99,6 +99,62 @@ func TestAPIConfigAddressesAndFlags(t *testing.T) {
 	}
 }
 
+func TestAPIConfigA2ARoutingAndAgentCardURL(t *testing.T) {
+	config := DefaultApiConfig().
+		SetHost("127.0.0.1").
+		SetPort(8024).
+		SetPublicURL("https://public.example/sandbox/").
+		SetA2APath("internal/a2a/").
+		SetA2APublicPath("public/a2a/")
+
+	if got, want := config.GetWebUrl(), "http://127.0.0.1:8024"; got != want {
+		t.Fatalf("GetWebUrl() = %q, want %q", got, want)
+	}
+	if got, want := config.GetA2APath(), "/internal/a2a"; got != want {
+		t.Fatalf("GetA2APath() = %q, want %q", got, want)
+	}
+	if got, want := config.GetA2APublicURL(), "https://public.example/sandbox/public/a2a"; got != want {
+		t.Fatalf("GetA2APublicURL() = %q, want %q", got, want)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "http://attacker.invalid/.well-known/agent-card.json", nil)
+	request.Host = "attacker.invalid"
+	request.Header.Set("Forwarded", `for=192.0.2.1;proto=http;host="attacker.invalid"`)
+	request.Header.Set("X-Forwarded-Proto", "http")
+	request.Header.Set("X-Forwarded-Host", "attacker.invalid")
+	if got, want := config.ResolveAgentCardURL(request), "https://public.example/sandbox/public/a2a"; got != want {
+		t.Fatalf("default ResolveAgentCardURL() = %q, want configured URL %q", got, want)
+	}
+	staticConfig := DefaultApiConfig().SetHost("127.0.0.1").SetPort(8024).SetA2APath("/a2a")
+	if got, want := staticConfig.ResolveAgentCardURL(request), "http://127.0.0.1:8024/a2a"; got != want {
+		t.Fatalf("default resolver without PublicURL = %q, want listener-derived URL %q", got, want)
+	}
+
+	config.SetAgentCardURLResolver(ForwardedAgentCardURL)
+	request.Header.Set("Forwarded", `for=192.0.2.1;proto=https;host="proxy.example:8443"`)
+	if got, want := config.ResolveAgentCardURL(request), "https://proxy.example:8443/public/a2a"; got != want {
+		t.Fatalf("forwarded ResolveAgentCardURL() = %q, want %q", got, want)
+	}
+
+	request.Header.Set("Forwarded", "")
+	request.Header.Set("X-Forwarded-Proto", "https")
+	request.Header.Set("X-Forwarded-Host", "legacy-proxy.example")
+	if got, want := config.ResolveAgentCardURL(request), "https://legacy-proxy.example/public/a2a"; got != want {
+		t.Fatalf("X-Forwarded ResolveAgentCardURL() = %q, want %q", got, want)
+	}
+
+	request.Host = "bad host"
+	request.Header.Set("X-Forwarded-Host", "user@example.invalid")
+	if got, want := config.ResolveAgentCardURL(request), config.GetA2APublicURL(); got != want {
+		t.Fatalf("invalid forwarded host resolved to %q, want fallback %q", got, want)
+	}
+
+	config.SetA2APublicPath("")
+	if got, want := config.GetA2APublicURL(), "https://public.example/sandbox/internal/a2a"; got != want {
+		t.Fatalf("inherited A2A public URL = %q, want %q", got, want)
+	}
+}
+
 type lifecycleTestApp struct {
 	config *ApiConfig
 	setup  func(*mux.Router) error
@@ -338,6 +394,15 @@ func TestRunRedactsSetupAndConfigurationErrors(t *testing.T) {
 	err = invalid.Run(context.Background(), &RunConfig{DisableObservability: true})
 	if err == nil || err.Error() != "validate server configuration failed" {
 		t.Fatalf("invalid CORS error = %v", err)
+	}
+
+	invalidPublicURL := &lifecycleTestApp{config: DefaultApiConfig().SetPublicURL("https://user:secret@example.test/a2a")}
+	err = invalidPublicURL.Run(context.Background(), &RunConfig{DisableObservability: true})
+	if err == nil || err.Error() != "validate server configuration failed" {
+		t.Fatalf("invalid public URL error = %v", err)
+	}
+	if strings.Contains(err.Error(), "secret") {
+		t.Fatalf("invalid public URL error leaked user info: %v", err)
 	}
 }
 

--- a/examples/a2a/main.go
+++ b/examples/a2a/main.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"context"
+	"flag"
+	"os"
 
 	"github.com/volcengine/veadk-go/agent/remoteagent"
 	"github.com/volcengine/veadk-go/apps"
@@ -25,20 +27,27 @@ import (
 )
 
 func main() {
+	remoteURL := flag.String("remote-url", "http://127.0.0.1:8000", "remote A2A server base URL")
+	host := flag.String("host", "127.0.0.1", "HTTP listen host")
+	port := flag.Int("port", 8001, "HTTP listen port")
+	flag.Parse()
+
 	ctx := context.Background()
 
 	remoteAgent, err := remoteagent.NewVeRemoteAgent(
 		remoteagent.NewDefaultConfig().
 			SetName("remoteAgent").
-			SetApiKey("your api key").
-			SetBaseUrl("you base url"),
+			SetApiKey(os.Getenv("REMOTE_AGENT_API_KEY")).
+			SetBaseUrl(*remoteURL),
 	)
 	if err != nil {
 		log.Errorf("Failed to create a remote agent: %v", err)
 		return
 	}
 
-	app := agentkit_server_app.NewAgentkitServerApp(apps.DefaultApiConfig())
+	app := agentkit_server_app.NewAgentkitServerApp(
+		apps.DefaultApiConfig().SetHost(*host).SetPort(*port),
+	)
 
 	err = app.Run(ctx, &apps.RunConfig{
 		AgentLoader: agent.NewSingleLoader(remoteAgent),

--- a/examples/apps/a2a_app/main.go
+++ b/examples/apps/a2a_app/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"flag"
 
 	veagent "github.com/volcengine/veadk-go/agent/llmagent"
 	"github.com/volcengine/veadk-go/apps"
@@ -25,6 +26,14 @@ import (
 )
 
 func main() {
+	host := flag.String("host", "127.0.0.1", "HTTP listen host")
+	port := flag.Int("port", 8000, "HTTP listen port")
+	a2aPath := flag.String("a2a-path", "/", "internal A2A JSON-RPC route")
+	a2aPublicPath := flag.String("a2a-public-path", "", "A2A route advertised by Agent Cards (defaults to --a2a-path)")
+	publicURL := flag.String("public-url", "", "external base URL advertised by Agent Cards")
+	trustProxyHeaders := flag.Bool("trust-proxy-headers", false, "trust Forwarded and X-Forwarded-* headers from a reverse proxy")
+	flag.Parse()
+
 	ctx := context.Background()
 
 	a, err := veagent.New(&veagent.Config{})
@@ -33,7 +42,17 @@ func main() {
 		return
 	}
 
-	a2aApp := a2a_app.NewAgentkitA2AServerApp(apps.DefaultApiConfig())
+	apiConfig := apps.DefaultApiConfig().
+		SetHost(*host).
+		SetPort(*port).
+		SetA2APath(*a2aPath).
+		SetA2APublicPath(*a2aPublicPath).
+		SetPublicURL(*publicURL)
+	if *trustProxyHeaders {
+		apiConfig.SetAgentCardURLResolver(apps.ForwardedAgentCardURL)
+	}
+
+	a2aApp := a2a_app.NewAgentkitA2AServerApp(apiConfig)
 
 	err = a2aApp.Run(ctx, &apps.RunConfig{
 		AgentLoader: agent.NewSingleLoader(a),

--- a/examples/apps/agentkit_server_app/main.go
+++ b/examples/apps/agentkit_server_app/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"flag"
 
 	veagent "github.com/volcengine/veadk-go/agent/llmagent"
 	"github.com/volcengine/veadk-go/apps"
@@ -25,6 +26,14 @@ import (
 )
 
 func main() {
+	host := flag.String("host", "127.0.0.1", "HTTP listen host")
+	port := flag.Int("port", 8000, "HTTP listen port")
+	a2aPath := flag.String("a2a-path", "/", "internal A2A JSON-RPC route")
+	a2aPublicPath := flag.String("a2a-public-path", "", "A2A route advertised by Agent Cards (defaults to --a2a-path)")
+	publicURL := flag.String("public-url", "", "external base URL advertised by Agent Cards")
+	trustProxyHeaders := flag.Bool("trust-proxy-headers", false, "trust Forwarded and X-Forwarded-* headers from a reverse proxy")
+	flag.Parse()
+
 	ctx := context.Background()
 
 	a, err := veagent.New(&veagent.Config{})
@@ -33,7 +42,17 @@ func main() {
 		return
 	}
 
-	app := agentkit_server_app.NewAgentkitServerApp(apps.DefaultApiConfig())
+	apiConfig := apps.DefaultApiConfig().
+		SetHost(*host).
+		SetPort(*port).
+		SetA2APath(*a2aPath).
+		SetA2APublicPath(*a2aPublicPath).
+		SetPublicURL(*publicURL)
+	if *trustProxyHeaders {
+		apiConfig.SetAgentCardURLResolver(apps.ForwardedAgentCardURL)
+	}
+
+	app := agentkit_server_app.NewAgentkitServerApp(apiConfig)
 
 	err = app.Run(ctx, &apps.RunConfig{
 		AgentLoader: agent.NewSingleLoader(a),


### PR DESCRIPTION
## Summary

- add separate internal and externally advertised A2A paths plus an explicit public base URL
- serve both standard Agent Card discovery paths and keep request-derived proxy URLs opt-in
- validate forwarded scheme/host data and fall back to static configuration on invalid resolver output
- make the A2A, combined server, and remote-agent examples directly runnable with local routing flags
- verify message/send, tasks/get, message/stream, and tasks/cancel through real HTTP/SSE boundaries

## Contract coverage

- default Agent Cards ignore Host, Forwarded, and X-Forwarded-* input
- trusted-proxy deployments can explicitly select ForwardedAgentCardURL
- non-blocking send/poll covers completed, failed, rejected, canceled, unknown, missing, empty-text, metadata, historyLength, and isolated concurrent sessions
- SSE covers submitted/working/artifact/final ordering, incremental artifacts, failed terminal events, and disconnect followed by polling
- cancellation covers context propagation, idempotency, terminal/unknown tasks, and cancel/complete races

## Example smoke tests

- examples/apps/a2a_app: both Agent Cards, message/send, tasks/get, and message/stream against a real configured model
- examples/a2a: remote-agent proxy forwarded an A2A request end to end through the preceding server
- examples/apps/agentkit_server_app: health, Agent Card, and message/send on a custom /rpc route
- all example packages compile, test, and pass go vet

## Validation

- go test -count=10 -gcflags="all=-N -l" ./apps/a2a_app
- go test -race -count=1 -shuffle=on -gcflags="all=-N -l" ./apps ./apps/a2a_app ./apps/agentkit_server_app ./apps/simple_app
- go test -count=1 ./examples/...
- go vet ./examples/...
- go build -mod=readonly ./...
- go mod tidy -diff
- go vet on all non-config packages
- golangci-lint v2.13.2: 0 issues for changed A2A app and example packages