### PR TITLE
feat(skills): add local discovery and lazy resources

### DIFF
--- a/agent/llmagent/agent.go
+++ b/agent/llmagent/agent.go
@@ -25,6 +25,7 @@ import (
 	"github.com/volcengine/veadk-go/knowledgebase"
 	"github.com/volcengine/veadk-go/model"
 	"github.com/volcengine/veadk-go/prompts"
+	"github.com/volcengine/veadk-go/skills"
 	"github.com/volcengine/veadk-go/tool/builtin_tools"
 	"github.com/volcengine/veadk-go/utils"
 	"google.golang.org/adk/agent"
@@ -46,9 +47,17 @@ type Config struct {
 	KnowledgeBase       *knowledgebase.KnowledgeBase
 	PromptManager       prompts.BasePromptManager
 	DisableThought      bool
+	// Skills contains local root directories whose immediate child directories
+	// are individual skills. Skills are discovered when the agent is created.
+	Skills                []string
+	SkillDiscoveryOptions skills.DiscoveryOptions
 }
 
 func New(cfg *Config) (agent.Agent, error) {
+	if err := configureLocalSkills(cfg); err != nil {
+		return nil, err
+	}
+
 	if cfg.Name == "" {
 		cfg.Name = common.DEFAULT_LLMAGENT_NAME
 	}

--- a/agent/llmagent/local_skills.go
+++ b/agent/llmagent/local_skills.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llmagent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/volcengine/veadk-go/skills"
+	"github.com/volcengine/veadk-go/tool/skilltool"
+)
+
+func configureLocalSkills(cfg *Config) error {
+	if cfg == nil {
+		return fmt.Errorf("llmagent config is required")
+	}
+
+	discovered := make([]*skills.Skill, 0)
+	sources := make(map[string]string)
+	for _, root := range cfg.Skills {
+		if strings.TrimSpace(root) == "" {
+			continue
+		}
+		rootSkills, err := skills.DiscoverSkillsFromDirWithOptions(
+			context.Background(),
+			root,
+			cfg.SkillDiscoveryOptions,
+		)
+		if err != nil {
+			return fmt.Errorf("discover local skills from %q: %w", root, err)
+		}
+		for _, skill := range rootSkills {
+			if previousRoot, ok := sources[skill.Name()]; ok {
+				return fmt.Errorf("%w %q from %q and %q", skills.ErrDuplicateSkill, skill.Name(), previousRoot, root)
+			}
+			sources[skill.Name()] = root
+			discovered = append(discovered, skill)
+		}
+	}
+	if len(discovered) == 0 {
+		return nil
+	}
+
+	toolset, err := skilltool.NewReadOnlySkillToolset(discovered)
+	if err != nil {
+		return fmt.Errorf("create local skill toolset: %w", err)
+	}
+	cfg.Toolsets = append(cfg.Toolsets, toolset)
+	return nil
+}

--- a/agent/llmagent/local_skills_test.go
+++ b/agent/llmagent/local_skills_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llmagent
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/volcengine/veadk-go/skills"
+	adkllmagent "google.golang.org/adk/agent/llmagent"
+	adkmodel "google.golang.org/adk/model"
+)
+
+type localSkillsTestModel struct{}
+
+func (localSkillsTestModel) Name() string { return "local-skills-test" }
+
+func (localSkillsTestModel) GenerateContent(context.Context, *adkmodel.LLMRequest, bool) iter.Seq2[*adkmodel.LLMResponse, error] {
+	return func(yield func(*adkmodel.LLMResponse, error) bool) {}
+}
+
+func TestNewDiscoversSkillsFromRootDirectory(t *testing.T) {
+	root := t.TempDir()
+	writeAgentTestSkill(t, root, "zeta", "last")
+	writeAgentTestSkill(t, root, "alpha", "first")
+
+	cfg := &Config{
+		Config: adkllmagent.Config{
+			Name:  "root-directory-skills",
+			Model: localSkillsTestModel{},
+		},
+		Skills: []string{"  ", root},
+	}
+	if _, err := New(cfg); err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if got := len(cfg.Toolsets); got != 1 {
+		t.Fatalf("Toolsets count = %d, want 1", got)
+	}
+	tools, err := cfg.Toolsets[0].Tools(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, skillTool := range tools {
+		names = append(names, skillTool.Name())
+	}
+	if got, want := strings.Join(names, ","), "list_skills,load_skill,load_skill_resource"; got != want {
+		t.Fatalf("skill tools = %q, want %q", got, want)
+	}
+}
+
+func TestNewLocalSkillsHonorsStrictDiscovery(t *testing.T) {
+	root := t.TempDir()
+	writeAgentTestSkill(t, root, "valid", "valid")
+	if err := os.MkdirAll(filepath.Join(root, "invalid"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{
+		Config: adkllmagent.Config{Name: "strict-skills", Model: localSkillsTestModel{}},
+		Skills: []string{root},
+		SkillDiscoveryOptions: skills.DiscoveryOptions{
+			Mode: skills.DiscoveryStrict,
+		},
+	}
+	if _, err := New(cfg); err == nil {
+		t.Fatal("New() strict discovery error = nil")
+	}
+	if len(cfg.Toolsets) != 0 {
+		t.Fatal("New() mutated toolsets after strict discovery failure")
+	}
+}
+
+func TestNewLocalSkillsRejectsDuplicateNamesAcrossRoots(t *testing.T) {
+	firstRoot := t.TempDir()
+	secondRoot := t.TempDir()
+	writeAgentTestSkill(t, firstRoot, "duplicate", "first")
+	writeAgentTestSkill(t, secondRoot, "duplicate", "second")
+
+	_, err := New(&Config{
+		Config: adkllmagent.Config{Name: "duplicate-skills", Model: localSkillsTestModel{}},
+		Skills: []string{firstRoot, secondRoot},
+	})
+	if !errors.Is(err, skills.ErrDuplicateSkill) {
+		t.Fatalf("New() error = %v, want ErrDuplicateSkill", err)
+	}
+}
+
+func writeAgentTestSkill(t *testing.T, root, name, description string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	document := "---\nname: " + name + "\ndescription: " + description + "\n---\nUse this skill.\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(document), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/examples/skills/discovery/main.go
+++ b/examples/skills/discovery/main.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/volcengine/veadk-go/skills"
+)
+
+func main() {
+	root := flag.String("root", ".adk/skills", "directory whose immediate children are local skills")
+	strict := flag.Bool("strict", false, "fail if any immediate child skill is invalid")
+	resource := flag.String("resource", "", "optional skill-name:relative/path resource to verify")
+	flag.Parse()
+
+	mode := skills.DiscoverySkipInvalid
+	if *strict {
+		mode = skills.DiscoveryStrict
+	}
+	discovered, err := skills.DiscoverSkillsFromDirWithOptions(context.Background(), *root, skills.DiscoveryOptions{
+		Mode: mode,
+		OnIssue: func(issue skills.DiscoveryIssue) {
+			fmt.Fprintf(os.Stderr, "invalid skill %q: %v\n", issue.Entry, issue.Err)
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discovery failed: %v\n", err)
+		os.Exit(1)
+	}
+	for _, skill := range discovered {
+		fmt.Printf("%s\t%s\n", skill.Name(), skill.Description())
+	}
+
+	if strings.TrimSpace(*resource) == "" {
+		return
+	}
+	skillName, resourcePath, ok := strings.Cut(*resource, ":")
+	if !ok || skillName == "" || resourcePath == "" {
+		fmt.Fprintln(os.Stderr, "resource must use skill-name:relative/path format")
+		os.Exit(2)
+	}
+	for _, skill := range discovered {
+		if skill.Name() != skillName {
+			continue
+		}
+		data, readErr := skill.ReadResourceContext(context.Background(), resourcePath, skills.DefaultMaxResourceBytes)
+		if readErr != nil {
+			fmt.Fprintf(os.Stderr, "resource verification failed: %v\n", readErr)
+			os.Exit(1)
+		}
+		digest := sha256.Sum256(data)
+		fmt.Printf("resource\t%s\t%d bytes\tsha256:%s\n", resourcePath, len(data), hex.EncodeToString(digest[:]))
+		return
+	}
+	fmt.Fprintf(os.Stderr, "skill %q was not discovered\n", skillName)
+	os.Exit(1)
+}

--- a/examples/skills/main.go
+++ b/examples/skills/main.go
@@ -16,45 +16,26 @@ package main
 
 import (
 	"context"
-	"time"
+	"os"
 
 	veagent "github.com/volcengine/veadk-go/agent/llmagent"
 	"github.com/volcengine/veadk-go/apps"
 	"github.com/volcengine/veadk-go/apps/agentkit_server_app"
-	"github.com/volcengine/veadk-go/code_executors"
 	"github.com/volcengine/veadk-go/log"
-	"github.com/volcengine/veadk-go/skills"
-	"github.com/volcengine/veadk-go/tool/skilltool"
 	"google.golang.org/adk/agent"
 	"google.golang.org/adk/agent/llmagent"
-	adktool "google.golang.org/adk/tool"
 )
 
 func main() {
 	ctx := context.Background()
 
-	skillPathList := []string{
-		".adk/skills/multiplication-calculator",
-		".adk/skills/image-generate",
-		".adk/skills/video-generate",
-	}
-	var skillList []*skills.Skill
-	for _, path := range skillPathList {
-		skill, err := skills.LoadSkillFromDir(path)
-		if err != nil {
-			panic(err)
-		}
-		skillList = append(skillList, skill)
-	}
-
-	skillToolset, err := skilltool.NewSkillToolset(skillList, code_executors.NewUnsafeLocalCodeExecutor(300*time.Second))
-	if err != nil {
-		panic(err)
+	skillsRoot := os.Getenv("VEADK_SKILLS_DIR")
+	if skillsRoot == "" {
+		skillsRoot = ".adk/skills"
 	}
 	a, err := veagent.New(&veagent.Config{
-		Config: llmagent.Config{
-			Toolsets: []adktool.Toolset{skillToolset},
-		},
+		Config: llmagent.Config{},
+		Skills: []string{skillsRoot},
 	})
 	if err != nil {
 		log.Errorf("NewLLMAgent failed: %v", err)

--- a/skills/discovery.go
+++ b/skills/discovery.go
@@ -1,0 +1,296 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/volcengine/veadk-go/log"
+)
+
+const DefaultMaxSkillDocumentBytes int64 = 1024 * 1024
+
+var (
+	ErrInvalidDiscoveryMode  = errors.New("invalid skill discovery mode")
+	ErrSkillDocumentTooLarge = errors.New("skill document is too large")
+	ErrDuplicateSkill        = errors.New("duplicate skill name")
+)
+
+// DiscoveryMode controls whether malformed immediate child directories are
+// skipped or returned to the caller as an aggregate error.
+type DiscoveryMode uint8
+
+const (
+	DiscoverySkipInvalid DiscoveryMode = iota
+	DiscoveryStrict
+)
+
+// DiscoveryIssue describes one child directory which could not be loaded.
+// Entry contains only the child name, not the contents of its SKILL.md.
+type DiscoveryIssue struct {
+	Entry string
+	Err   error
+}
+
+func (e *DiscoveryIssue) Error() string {
+	if e == nil {
+		return "skill discovery failed"
+	}
+	return fmt.Sprintf("discover skill %q: %v", e.Entry, e.Err)
+}
+
+func (e *DiscoveryIssue) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// DiscoveryOptions configures local metadata-first discovery.
+type DiscoveryOptions struct {
+	Mode                  DiscoveryMode
+	MaxSkillDocumentBytes int64
+	OnIssue               func(DiscoveryIssue)
+}
+
+// DiscoverSkillsFromDir discovers valid skills in immediate child
+// directories. Invalid children are skipped and logged. Resources are not
+// traversed or loaded.
+func DiscoverSkillsFromDir(skillsDir string) ([]*Skill, error) {
+	return DiscoverSkillsFromDirWithOptions(context.Background(), skillsDir, DiscoveryOptions{})
+}
+
+// DiscoverSkillsFromDirWithOptions discovers valid skills in immediate child
+// directories in stable name order. In strict mode it returns all valid skills
+// together with an aggregate error for invalid children.
+func DiscoverSkillsFromDirWithOptions(ctx context.Context, skillsDir string, options DiscoveryOptions) ([]*Skill, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if options.Mode != DiscoverySkipInvalid && options.Mode != DiscoveryStrict {
+		return nil, ErrInvalidDiscoveryMode
+	}
+	maxBytes := options.MaxSkillDocumentBytes
+	if maxBytes == 0 {
+		maxBytes = DefaultMaxSkillDocumentBytes
+	}
+	if maxBytes < 0 {
+		return nil, fmt.Errorf("%w: maximum SKILL.md size must not be negative", ErrSkillDocumentTooLarge)
+	}
+
+	abs, err := filepath.Abs(skillsDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve skills directory: %w", err)
+	}
+	root, err := os.OpenRoot(abs)
+	if err != nil {
+		return nil, fmt.Errorf("open skills directory: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	entries, err := fs.ReadDir(root.FS(), ".")
+	if err != nil {
+		return nil, fmt.Errorf("read skills directory: %w", err)
+	}
+
+	discovered := make([]*Skill, 0, len(entries))
+	seen := make(map[string]string, len(entries))
+	issues := make([]error, 0)
+	report := func(entry string, issueErr error) {
+		issue := DiscoveryIssue{Entry: entry, Err: issueErr}
+		if options.OnIssue != nil {
+			options.OnIssue(issue)
+		}
+		log.Warnf("Skipping invalid skill directory %q: %v", entry, issueErr)
+		if options.Mode == DiscoveryStrict {
+			issues = append(issues, &issue)
+		}
+	}
+
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return discovered, err
+		}
+		if entry.Type()&os.ModeSymlink != 0 || !entry.IsDir() {
+			continue
+		}
+
+		childRoot, openErr := root.OpenRoot(entry.Name())
+		if openErr != nil {
+			report(entry.Name(), fmt.Errorf("open directory: %w", openErr))
+			continue
+		}
+		skill, loadErr := parseSkillRoot(ctx, childRoot, filepath.Join(abs, entry.Name()), maxBytes, false)
+		closeErr := childRoot.Close()
+		if loadErr == nil && closeErr != nil {
+			loadErr = fmt.Errorf("close directory: %w", closeErr)
+		}
+		if loadErr != nil {
+			report(entry.Name(), loadErr)
+			continue
+		}
+		if skill.Name() != entry.Name() {
+			report(entry.Name(), fmt.Errorf("declared name %q does not match directory name", skill.Name()))
+			continue
+		}
+		if previous, ok := seen[skill.Name()]; ok {
+			report(entry.Name(), fmt.Errorf("%w %q (already provided by %q)", ErrDuplicateSkill, skill.Name(), previous))
+			continue
+		}
+		seen[skill.Name()] = entry.Name()
+		discovered = append(discovered, skill)
+	}
+
+	if len(issues) != 0 {
+		return discovered, errors.Join(issues...)
+	}
+	return discovered, nil
+}
+
+func parseSkillMD(skillDir string) (*Skill, error) {
+	abs, err := filepath.Abs(skillDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve skill directory: %w", err)
+	}
+	root, err := os.OpenRoot(abs)
+	if err != nil {
+		return nil, fmt.Errorf("open skill directory: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+	return parseSkillRoot(context.Background(), root, abs, DefaultMaxSkillDocumentBytes, true)
+}
+
+func parseSkillRoot(ctx context.Context, root *os.Root, skillDir string, maxBytes int64, allowLegacyFilename bool) (*Skill, error) {
+	var (
+		file     *os.File
+		fileName string
+	)
+	candidates := []string{"SKILL.md"}
+	if allowLegacyFilename {
+		candidates = append(candidates, "skill.md")
+	}
+	for _, candidate := range candidates {
+		opened, err := root.Open(candidate)
+		if err == nil {
+			file = opened
+			fileName = candidate
+			break
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("open %s: %w", candidate, err)
+		}
+	}
+	if file == nil {
+		return nil, fmt.Errorf("SKILL.md not found")
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat SKILL.md: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("SKILL.md is not a regular file")
+	}
+	data, err := readBoundedContext(ctx, file, maxBytes, ErrSkillDocumentTooLarge)
+	if err != nil {
+		return nil, fmt.Errorf("read SKILL.md: %w", err)
+	}
+
+	skill, err := parseSkillDocument(data)
+	if err != nil {
+		return nil, err
+	}
+	skill.SkillMDPath = filepath.Join(skillDir, fileName)
+	log.Debugf("Successfully discovered local skill %q", skill.Name())
+	return skill, nil
+}
+
+func parseSkillDocument(data []byte) (*Skill, error) {
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+	text = strings.TrimSuffix(text, "\n")
+	lines := strings.Split(text, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return nil, fmt.Errorf("invalid SKILL.md frontmatter")
+	}
+
+	closing := -1
+	for index := 1; index < len(lines); index++ {
+		if strings.TrimSpace(lines[index]) == "---" {
+			closing = index
+			break
+		}
+	}
+	if closing < 0 {
+		return nil, fmt.Errorf("missing closing SKILL.md frontmatter separator")
+	}
+	if closing == 1 {
+		return nil, fmt.Errorf("empty SKILL.md frontmatter")
+	}
+
+	frontmatter, err := parseFrontmatter([]byte(strings.Join(lines[1:closing], "\n")))
+	if err != nil {
+		return nil, fmt.Errorf("parse SKILL.md frontmatter: %w", err)
+	}
+	if err := frontmatter.Validate(); err != nil {
+		return nil, fmt.Errorf("validate SKILL.md frontmatter: %w", err)
+	}
+
+	return &Skill{
+		Frontmatter:  frontmatter,
+		Instructions: strings.Join(lines[closing+1:], "\n"),
+	}, nil
+}
+
+func readBoundedContext(ctx context.Context, reader io.Reader, maxBytes int64, tooLarge error) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	limited := reader
+	if maxBytes < math.MaxInt64 {
+		limited = io.LimitReader(reader, maxBytes+1)
+	}
+	buffer := make([]byte, 0, min(maxBytes, 32*1024))
+	chunk := make([]byte, 32*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		count, err := limited.Read(chunk)
+		if count > 0 {
+			buffer = append(buffer, chunk[:count]...)
+			if int64(len(buffer)) > maxBytes {
+				return nil, fmt.Errorf("%w: limit is %d bytes", tooLarge, maxBytes)
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			return buffer, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+}

--- a/skills/discovery_test.go
+++ b/skills/discovery_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverSkillsFromDirIsMetadataFirstStableAndRooted(t *testing.T) {
+	realRoot := t.TempDir()
+	writeTestSkill(t, realRoot, "zeta-skill", "last", "Use zeta.")
+	writeTestSkill(t, realRoot, "alpha-skill", "first", "Use alpha.")
+	writeTestFile(t, filepath.Join(realRoot, "alpha-skill", "assets", "nested", "template.txt"), "not loaded at discovery")
+	writeTestFile(t, filepath.Join(realRoot, "README.md"), "not a skill")
+	writeTestSkill(t, filepath.Join(realRoot, "container"), "nested-skill", "nested", "not immediate")
+
+	linkedRoot := filepath.Join(t.TempDir(), "skills-link")
+	if err := os.Symlink(realRoot, linkedRoot); err != nil {
+		t.Fatal(err)
+	}
+	discovered, err := DiscoverSkillsFromDir(linkedRoot)
+	if err != nil {
+		t.Fatalf("DiscoverSkillsFromDir() error = %v", err)
+	}
+	if got, want := skillNames(discovered), []string{"alpha-skill", "zeta-skill"}; !slices.Equal(got, want) {
+		t.Fatalf("skill names = %v, want %v", got, want)
+	}
+	for _, skill := range discovered {
+		if skill.Resources != nil {
+			t.Fatalf("skill %q loaded resources eagerly", skill.Name())
+		}
+		if !strings.HasPrefix(skill.SkillMDPath, linkedRoot) {
+			t.Fatalf("SkillMDPath = %q, want path below supplied root %q", skill.SkillMDPath, linkedRoot)
+		}
+	}
+	if got, want := discovered[0].Instructions, "Use alpha."; got != want {
+		t.Fatalf("Instructions = %q, want %q", got, want)
+	}
+}
+
+func TestDiscoverSkillsFromDirSkipAndStrictDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	writeTestSkill(t, root, "valid-skill", "valid", "instructions")
+	writeTestFile(t, filepath.Join(root, "bad-yaml", "SKILL.md"), "---\nname: [\n---\n")
+	writeTestFile(t, filepath.Join(root, "mismatch", "SKILL.md"), "---\nname: another-name\ndescription: mismatch\n---\n")
+	writeTestFile(t, filepath.Join(root, "lowercase-only", "skill.md"), "---\nname: lowercase-only\ndescription: legacy filename\n---\n")
+	writeTestFile(t, filepath.Join(root, "oversized", "SKILL.md"), "---\nname: oversized\ndescription: "+strings.Repeat("x", 256)+"\n---\n")
+
+	var skipped []string
+	discovered, err := DiscoverSkillsFromDirWithOptions(t.Context(), root, DiscoveryOptions{
+		MaxSkillDocumentBytes: 128,
+		OnIssue: func(issue DiscoveryIssue) {
+			skipped = append(skipped, issue.Entry)
+		},
+	})
+	if err != nil {
+		t.Fatalf("skip discovery error = %v", err)
+	}
+	if got, want := skillNames(discovered), []string{"valid-skill"}; !slices.Equal(got, want) {
+		t.Fatalf("skill names = %v, want %v", got, want)
+	}
+	if got, want := skipped, []string{"bad-yaml", "lowercase-only", "mismatch", "oversized"}; !slices.Equal(got, want) {
+		t.Fatalf("issues = %v, want %v", got, want)
+	}
+
+	var strictIssues []DiscoveryIssue
+	partial, err := DiscoverSkillsFromDirWithOptions(t.Context(), root, DiscoveryOptions{
+		Mode:                  DiscoveryStrict,
+		MaxSkillDocumentBytes: 128,
+		OnIssue: func(issue DiscoveryIssue) {
+			strictIssues = append(strictIssues, issue)
+		},
+	})
+	if err == nil {
+		t.Fatal("strict discovery error = nil")
+	}
+	if got, want := skillNames(partial), []string{"valid-skill"}; !slices.Equal(got, want) {
+		t.Fatalf("partial skill names = %v, want %v", got, want)
+	}
+	if len(strictIssues) != 4 {
+		t.Fatalf("strict issue count = %d, want 4", len(strictIssues))
+	}
+	var issue *DiscoveryIssue
+	if !errors.As(err, &issue) {
+		t.Fatalf("strict error %T does not contain DiscoveryIssue", err)
+	}
+	if !errors.Is(err, ErrSkillDocumentTooLarge) {
+		t.Fatalf("strict error = %v, want ErrSkillDocumentTooLarge", err)
+	}
+}
+
+func TestDiscoverSkillsFromDirContextAndOptions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := DiscoverSkillsFromDirWithOptions(ctx, t.TempDir(), DiscoveryOptions{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled discovery error = %v, want context.Canceled", err)
+	}
+	if _, err := DiscoverSkillsFromDirWithOptions(t.Context(), t.TempDir(), DiscoveryOptions{Mode: DiscoveryMode(99)}); !errors.Is(err, ErrInvalidDiscoveryMode) {
+		t.Fatalf("invalid mode error = %v, want ErrInvalidDiscoveryMode", err)
+	}
+	if _, err := DiscoverSkillsFromDirWithOptions(t.Context(), t.TempDir(), DiscoveryOptions{MaxSkillDocumentBytes: -1}); !errors.Is(err, ErrSkillDocumentTooLarge) {
+		t.Fatalf("negative limit error = %v, want ErrSkillDocumentTooLarge", err)
+	}
+}
+
+func TestLoadSkillFromDirKeepsLegacyLowercaseFilenameCompatibility(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "legacy-skill")
+	writeTestFile(t, filepath.Join(dir, "skill.md"), "---\nname: legacy-skill\ndescription: legacy\n---\ninstructions\n")
+	skill, err := LoadSkillFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadSkillFromDir() error = %v", err)
+	}
+	if got, want := filepath.Base(skill.SkillMDPath), "skill.md"; got != want {
+		t.Fatalf("SkillMDPath base = %q, want %q", got, want)
+	}
+}
+
+func TestDiscoverSkillsFromDirReportsUnreadableSkill(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can read files regardless of permission bits")
+	}
+	root := t.TempDir()
+	path := filepath.Join(root, "unreadable", "SKILL.md")
+	writeTestFile(t, path, "---\nname: unreadable\ndescription: unreadable\n---\n")
+	if err := os.Chmod(path, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+	var issues []DiscoveryIssue
+	discovered, err := DiscoverSkillsFromDirWithOptions(t.Context(), root, DiscoveryOptions{
+		OnIssue: func(issue DiscoveryIssue) { issues = append(issues, issue) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(discovered) != 0 || len(issues) != 1 || issues[0].Entry != "unreadable" {
+		t.Fatalf("discovered=%v issues=%v, want one unreadable issue", skillNames(discovered), issues)
+	}
+}
+
+func skillNames(skillList []*Skill) []string {
+	names := make([]string, 0, len(skillList))
+	for _, skill := range skillList {
+		names = append(names, skill.Name())
+	}
+	return names
+}
+
+func writeTestSkill(t *testing.T, root, name, description, instructions string) {
+	t.Helper()
+	writeTestFile(t, filepath.Join(root, name, "SKILL.md"), fmtSkillDocument(name, description, instructions))
+}
+
+func fmtSkillDocument(name, description, instructions string) string {
+	return "---\nname: " + name + "\ndescription: " + description + "\n---\n" + instructions + "\n"
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/skills/resource.go
+++ b/skills/resource.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const DefaultMaxResourceBytes int64 = 16 * 1024 * 1024
+
+var (
+	ErrInvalidResourcePath = errors.New("invalid skill resource path")
+	ErrResourceNotFound    = errors.New("skill resource not found")
+	ErrResourceTooLarge    = errors.New("skill resource is too large")
+	ErrResourceNotRegular  = errors.New("skill resource is not a regular file")
+	ErrResourceChanged     = errors.New("skill resource changed while opening")
+	ErrResourceRead        = errors.New("skill resource read failed")
+)
+
+// ReadResource reads a relative file without allowing access outside the skill
+// directory. A zero maxBytes uses
+// DefaultMaxResourceBytes; negative limits are rejected.
+func (s *Skill) ReadResource(resourcePath string, maxBytes int64) ([]byte, error) {
+	return s.ReadResourceContext(context.Background(), resourcePath, maxBytes)
+}
+
+// ReadResourceContext is ReadResource with cancellation support.
+func (s *Skill) ReadResourceContext(ctx context.Context, resourcePath string, maxBytes int64) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if maxBytes == 0 {
+		maxBytes = DefaultMaxResourceBytes
+	}
+	if maxBytes < 0 {
+		return nil, fmt.Errorf("%w: maximum size must not be negative", ErrResourceTooLarge)
+	}
+
+	cleaned, err := cleanResourcePath(resourcePath)
+	if err != nil {
+		return nil, err
+	}
+	if s == nil {
+		return nil, ErrResourceNotFound
+	}
+	if strings.TrimSpace(s.SkillMDPath) == "" {
+		return s.readInMemoryResource(ctx, cleaned, maxBytes)
+	}
+	return s.readDiskResource(ctx, cleaned, maxBytes)
+}
+
+func cleanResourcePath(resourcePath string) (string, error) {
+	normalized := strings.ReplaceAll(strings.TrimSpace(resourcePath), "\\", "/")
+	if normalized == "" || filepath.IsAbs(filepath.FromSlash(normalized)) || hasWindowsVolumePrefix(normalized) {
+		return "", fmt.Errorf("%w: path must be relative", ErrInvalidResourcePath)
+	}
+	cleaned := filepath.Clean(filepath.FromSlash(normalized))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: path escapes the skill directory", ErrInvalidResourcePath)
+	}
+	return cleaned, nil
+}
+
+func hasWindowsVolumePrefix(path string) bool {
+	return len(path) >= 3 && ((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z')) && path[1] == ':' && path[2] == '/'
+}
+
+func (s *Skill) readDiskResource(ctx context.Context, cleaned string, maxBytes int64) ([]byte, error) {
+	root, err := os.OpenRoot(s.GetSkillPath())
+	if err != nil {
+		return nil, fmt.Errorf("%w: open skill root", ErrResourceRead)
+	}
+	defer func() { _ = root.Close() }()
+
+	if err := validateResolvedResourcePath(s.GetSkillPath(), cleaned); err != nil {
+		return nil, err
+	}
+	before, err := root.Stat(cleaned)
+	if err != nil {
+		return nil, classifyResourceOpenError(err)
+	}
+	if !before.Mode().IsRegular() {
+		return nil, ErrResourceNotRegular
+	}
+	if before.Size() > maxBytes {
+		return nil, fmt.Errorf("%w: limit is %d bytes", ErrResourceTooLarge, maxBytes)
+	}
+
+	file, err := root.Open(cleaned)
+	if err != nil {
+		return nil, classifyResourceOpenError(err)
+	}
+	defer func() { _ = file.Close() }()
+	afterOpen, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("%w: stat opened resource", ErrResourceRead)
+	}
+	if !afterOpen.Mode().IsRegular() {
+		return nil, ErrResourceNotRegular
+	}
+	if !os.SameFile(before, afterOpen) {
+		return nil, ErrResourceChanged
+	}
+
+	data, err := readBoundedContext(ctx, file, maxBytes, ErrResourceTooLarge)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, ErrResourceTooLarge) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: read resource", ErrResourceRead)
+	}
+	afterRead, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("%w: stat resource after read", ErrResourceRead)
+	}
+	if afterRead.Size() != afterOpen.Size() || !afterRead.ModTime().Equal(afterOpen.ModTime()) {
+		return nil, ErrResourceChanged
+	}
+	return data, nil
+}
+
+func validateResolvedResourcePath(rootPath, cleaned string) error {
+	resolvedRoot, err := filepath.EvalSymlinks(rootPath)
+	if err != nil {
+		return fmt.Errorf("%w: resolve skill root", ErrResourceRead)
+	}
+	resolvedTarget, err := filepath.EvalSymlinks(filepath.Join(resolvedRoot, cleaned))
+	if err != nil {
+		return classifyResourceOpenError(err)
+	}
+	relative, err := filepath.Rel(resolvedRoot, resolvedTarget)
+	if err != nil {
+		return fmt.Errorf("%w: resolve resource path", ErrResourceRead)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return fmt.Errorf("%w: symbolic link escapes the skill directory", ErrInvalidResourcePath)
+	}
+	return nil
+}
+
+func classifyResourceOpenError(err error) error {
+	if errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("%w: %w", ErrResourceNotFound, fs.ErrNotExist)
+	}
+	return fmt.Errorf("%w: open resource", ErrResourceRead)
+}
+
+func (s *Skill) readInMemoryResource(ctx context.Context, cleaned string, maxBytes int64) ([]byte, error) {
+	if s.Resources == nil {
+		return nil, ErrResourceNotFound
+	}
+	parts := strings.SplitN(filepath.ToSlash(cleaned), "/", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return nil, fmt.Errorf("%w: in-memory paths must start with references/, assets/, or scripts/", ErrInvalidResourcePath)
+	}
+	var (
+		content string
+		found   bool
+	)
+	switch parts[0] {
+	case "references":
+		content, found = s.Resources.GetReference(parts[1])
+	case "assets":
+		content, found = s.Resources.GetAsset(parts[1])
+	case "scripts":
+		var script *Script
+		script, found = s.Resources.GetScript(parts[1])
+		if found && script != nil {
+			content = script.Src
+		} else {
+			found = false
+		}
+	default:
+		return nil, fmt.Errorf("%w: in-memory paths must start with references/, assets/, or scripts/", ErrInvalidResourcePath)
+	}
+	if !found {
+		return nil, ErrResourceNotFound
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	data := []byte(content)
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%w: limit is %d bytes", ErrResourceTooLarge, maxBytes)
+	}
+	return data, nil
+}

--- a/skills/resource_linux_test.go
+++ b/skills/resource_linux_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestReadResourceRejectsSpecialFileWithoutOpeningIt(t *testing.T) {
+	root := t.TempDir()
+	writeTestSkill(t, root, "special-skill", "special files", "instructions")
+	skillDir := filepath.Join(root, "special-skill")
+	pipePath := filepath.Join(skillDir, "assets", "input.pipe")
+	if err := os.MkdirAll(filepath.Dir(pipePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(pipePath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	skill, err := parseSkillMD(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := skill.ReadResource("assets/input.pipe", 1024); !errors.Is(err, ErrResourceNotRegular) {
+		t.Fatalf("special file error = %v, want ErrResourceNotRegular", err)
+	}
+}

--- a/skills/resource_test.go
+++ b/skills/resource_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skills
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestReadResourceFromDiskAndMemory(t *testing.T) {
+	root := t.TempDir()
+	writeTestSkill(t, root, "reader", "reads files", "instructions")
+	writeTestFile(t, filepath.Join(root, "reader", "references", "nested", "guide.md"), "guide")
+	writeTestFile(t, filepath.Join(root, "reader", "root-guide.md"), "root guide")
+	if err := os.Symlink("root-guide.md", filepath.Join(root, "reader", "linked-guide.md")); err != nil {
+		t.Fatal(err)
+	}
+	binary := []byte{0xff, 0x00, 0x01}
+	binaryPath := filepath.Join(root, "reader", "assets", "template.bin")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binaryPath, binary, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	discovered, err := DiscoverSkillsFromDir(root)
+	if err != nil || len(discovered) != 1 {
+		t.Fatalf("DiscoverSkillsFromDir() = %v, %v", skillNames(discovered), err)
+	}
+	for resourcePath, want := range map[string]string{
+		"references/nested/guide.md": "guide",
+		"root-guide.md":              "root guide",
+		"linked-guide.md":            "root guide",
+		"assets/template.bin":        string(binary),
+	} {
+		data, err := discovered[0].ReadResource(resourcePath, 1024)
+		if err != nil {
+			t.Fatalf("ReadResource(%q) error = %v", resourcePath, err)
+		}
+		if got := string(data); got != want {
+			t.Fatalf("ReadResource(%q) = %q, want %q", resourcePath, got, want)
+		}
+	}
+
+	inMemory := &Skill{Resources: &Resources{
+		References: map[string]string{"guide.md": "memory-guide"},
+		Assets:     map[string]string{"data.txt": "memory-asset"},
+		Scripts:    map[string]*Script{"run.py": {Src: "print('ok')"}},
+	}}
+	for resourcePath, want := range map[string]string{
+		"references/guide.md": "memory-guide",
+		"assets/data.txt":     "memory-asset",
+		"scripts/run.py":      "print('ok')",
+	} {
+		data, err := inMemory.ReadResource(resourcePath, 1024)
+		if err != nil || string(data) != want {
+			t.Fatalf("in-memory ReadResource(%q) = %q, %v", resourcePath, data, err)
+		}
+	}
+}
+
+func TestReadResourceRejectsInvalidPathsTypesAndSizes(t *testing.T) {
+	root := t.TempDir()
+	writeTestSkill(t, root, "safe-skill", "safe resources", "instructions")
+	skillDir := filepath.Join(root, "safe-skill")
+	writeTestFile(t, filepath.Join(skillDir, "assets", "small.txt"), "12345")
+	if err := os.MkdirAll(filepath.Join(skillDir, "assets", "directory"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(root, "outside.txt")
+	writeTestFile(t, outside, "outside-secret")
+	if err := os.Symlink(outside, filepath.Join(skillDir, "assets", "escape.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	skill, err := parseSkillMD(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, resourcePath := range []string{
+		"", ".", "..", "../outside.txt", "assets/../../outside.txt", "/etc/passwd",
+		"C:\\outside.txt", "assets/escape.txt",
+	} {
+		if _, err := skill.ReadResource(resourcePath, 1024); !errors.Is(err, ErrInvalidResourcePath) {
+			t.Errorf("ReadResource(%q) error = %v, want ErrInvalidResourcePath", resourcePath, err)
+		}
+	}
+	if _, err := skill.ReadResource("assets/missing.txt", 1024); !errors.Is(err, ErrResourceNotFound) {
+		t.Fatalf("missing resource error = %v, want ErrResourceNotFound", err)
+	}
+	if _, err := skill.ReadResource("unknown/file.txt", 1024); !errors.Is(err, ErrResourceNotFound) {
+		t.Fatalf("unknown resource error = %v, want ErrResourceNotFound", err)
+	}
+	if _, err := skill.ReadResource("assets", 1024); !errors.Is(err, ErrResourceNotRegular) {
+		t.Fatalf("resource directory error = %v, want ErrResourceNotRegular", err)
+	}
+	if _, err := skill.ReadResource("assets/directory", 1024); !errors.Is(err, ErrResourceNotRegular) {
+		t.Fatalf("directory error = %v, want ErrResourceNotRegular", err)
+	}
+	if _, err := skill.ReadResource("assets/small.txt", 4); !errors.Is(err, ErrResourceTooLarge) {
+		t.Fatalf("oversized resource error = %v, want ErrResourceTooLarge", err)
+	}
+	if data, err := skill.ReadResource("assets/small.txt", 5); err != nil || string(data) != "12345" {
+		t.Fatalf("exact-limit resource = %q, %v", data, err)
+	}
+	if _, err := skill.ReadResource("assets/small.txt", -1); !errors.Is(err, ErrResourceTooLarge) {
+		t.Fatalf("negative limit error = %v, want ErrResourceTooLarge", err)
+	}
+}
+
+func TestReadResourceHonorsCancellation(t *testing.T) {
+	root := t.TempDir()
+	writeTestSkill(t, root, "reader", "reads", "instructions")
+	writeTestFile(t, filepath.Join(root, "reader", "assets", "data.txt"), strings.Repeat("x", 128*1024))
+	skill, err := parseSkillMD(filepath.Join(root, "reader"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := skill.ReadResourceContext(ctx, "assets/data.txt", 256*1024); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ReadResourceContext() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestReadResourceSymlinkSwapNeverEscapesRoot(t *testing.T) {
+	root := t.TempDir()
+	writeTestSkill(t, root, "racing-skill", "race test", "instructions")
+	skillDir := filepath.Join(root, "racing-skill")
+	assetsDir := filepath.Join(skillDir, "assets")
+	writeTestFile(t, filepath.Join(assetsDir, "safe.txt"), "safe")
+	outside := filepath.Join(root, "outside.txt")
+	writeTestFile(t, outside, "outside-secret")
+	current := filepath.Join(assetsDir, "current.txt")
+	writeTestFile(t, current, "safe")
+
+	skill, err := parseSkillMD(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stop := make(chan struct{})
+	var mutation sync.WaitGroup
+	mutation.Add(1)
+	go func() {
+		defer mutation.Done()
+		safeReplacement := current + ".safe"
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = os.Remove(current)
+			_ = os.Symlink(outside, current)
+			_ = os.WriteFile(safeReplacement, []byte("safe"), 0o644)
+			_ = os.Rename(safeReplacement, current)
+		}
+	}()
+	for range 500 {
+		data, readErr := skill.ReadResource("assets/current.txt", 1024)
+		if readErr == nil && string(data) != "safe" {
+			close(stop)
+			mutation.Wait()
+			t.Fatalf("read escaped content %q", data)
+		}
+	}
+	close(stop)
+	mutation.Wait()
+}

--- a/skills/utils.go
+++ b/skills/utils.go
@@ -15,7 +15,6 @@
 package skills
 
 import (
-	"bufio"
 	"fmt"
 	"io/fs"
 	"os"
@@ -84,92 +83,15 @@ func parseFrontmatter(text []byte) (*Frontmatter, error) {
 	var skillMeta Frontmatter
 
 	if err := yaml.Unmarshal(text, &skillMeta); err != nil {
-		return nil, fmt.Errorf("failed to parse frontmatter {%s} error: %v", text, err)
+		return nil, fmt.Errorf("invalid YAML: %w", err)
 	}
 
 	if skillMeta.Name == "" || skillMeta.Description == "" {
-		return nil, fmt.Errorf("skill %s frontmatter is missing name or description. Please check the SKILL.md file", text)
+		return nil, fmt.Errorf("frontmatter is missing name or description")
 	}
 
-	log.Infof("Successfully loaded skill frontmatter ,name = %s,description=%s", skillMeta.Name, skillMeta.Description)
+	log.Debugf("Successfully loaded skill frontmatter, name=%s", skillMeta.Name)
 	return &skillMeta, nil
-}
-
-func parseSkillMD(skillDir string) (*Skill, error) {
-	var skill = &Skill{}
-	info, err := os.Stat(skillDir)
-	if err != nil {
-		return skill, fmt.Errorf("skill directory '%s' stat error:%w", skillDir, err)
-	}
-	if !info.IsDir() {
-		return skill, fmt.Errorf("skill directory '%s' is not a directory", skillDir)
-	}
-
-	var skillMD string
-	for _, name := range []string{"SKILL.md", "skill.md"} {
-		p := filepath.Join(skillDir, name)
-		if _, err := os.Stat(p); err == nil {
-			skillMD = p
-			break
-		}
-	}
-	if skillMD == "" {
-		return skill, fmt.Errorf("SKILL.md not found in '%s'", skillDir)
-	}
-
-	file, err := os.Open(skillMD)
-	if err != nil {
-		return skill, fmt.Errorf("open skill file '%s' error:%w", skillMD, err)
-	}
-	defer func() {
-		_ = file.Close()
-	}()
-	sc := bufio.NewScanner(file)
-	if !sc.Scan() {
-		return skill, err
-	}
-
-	if strings.TrimSpace(sc.Text()) != "---" {
-		return skill, fmt.Errorf("failed to parse %s, invalid frontmatter", skillMD)
-	}
-
-	var frontmatterLines []string
-	var contextLines []string
-	var isFrontmatterLines = true
-
-	for sc.Scan() {
-		line := sc.Text()
-		if isFrontmatterLines && strings.TrimSpace(line) == "---" {
-			if len(frontmatterLines) == 0 {
-				return nil, fmt.Errorf("failed to parse %s, empty frontmatter", skillMD)
-			}
-			isFrontmatterLines = false
-			frontmatterStr := strings.Join(frontmatterLines, "\n")
-			skill.Frontmatter, err = parseFrontmatter([]byte(frontmatterStr))
-			if err != nil {
-				return skill, fmt.Errorf("failed to parse frontmatter '%s', %w", skillMD, err)
-			}
-			if err := skill.Frontmatter.Validate(); err != nil {
-				return skill, fmt.Errorf("skill %s frontmatter invalid :%w", skillDir, err)
-			}
-			continue
-		}
-		if isFrontmatterLines {
-			frontmatterLines = append(frontmatterLines, line)
-		} else {
-			contextLines = append(contextLines, line)
-		}
-	}
-
-	if isFrontmatterLines {
-		return skill, fmt.Errorf("failed to parse %s, missing closing frontmatter separator", skillMD)
-	}
-
-	skill.Instructions = strings.Join(contextLines, "\n")
-	skill.SkillMDPath = skillMD
-
-	log.Infof("Successfully loaded skill %s locally from %s", skill.Frontmatter.Name, skillDir)
-	return skill, nil
 }
 
 func LoadSkillFromDir(skillDir string) (*Skill, error) {

--- a/tool/skilltool/lazy_resource_test.go
+++ b/tool/skilltool/lazy_resource_test.go
@@ -120,6 +120,33 @@ func TestNewSkillToolsetRejectsNilAndDuplicateSkills(t *testing.T) {
 	}
 }
 
+func TestNewReadOnlySkillToolsetOmitsScriptExecution(t *testing.T) {
+	root := t.TempDir()
+	writeLazySkillFile(t, filepath.Join(root, "lazy-skill", "SKILL.md"), "---\nname: lazy-skill\ndescription: lazy resources\n---\ninstructions\n")
+	discovered, err := skills.DiscoverSkillsFromDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toolset, err := NewReadOnlySkillToolset(discovered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tools, err := toolset.Tools(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, skillTool := range tools {
+		names = append(names, skillTool.Name())
+	}
+	if got, want := strings.Join(names, ","), "list_skills,load_skill,load_skill_resource"; got != want {
+		t.Fatalf("read-only tools = %q, want %q", got, want)
+	}
+	if strings.Contains(toolset.instruction, "run_skill_script") {
+		t.Fatal("read-only instruction advertises run_skill_script")
+	}
+}
+
 func writeLazySkillFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/tool/skilltool/lazy_resource_test.go
+++ b/tool/skilltool/lazy_resource_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skilltool
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/volcengine/veadk-go/skills"
+)
+
+func TestLoadSkillResourceToolReadsLazyTextAndBinary(t *testing.T) {
+	root := t.TempDir()
+	writeLazySkillFile(t, filepath.Join(root, "lazy-skill", "SKILL.md"), "---\nname: lazy-skill\ndescription: lazy resources\n---\ninstructions\n")
+	writeLazySkillFile(t, filepath.Join(root, "lazy-skill", "references", "guide.md"), "guide")
+	binary := []byte{0xff, 0x00, 0x01}
+	binaryPath := filepath.Join(root, "lazy-skill", "assets", "template.bin")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binaryPath, binary, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	discovered, err := skills.DiscoverSkillsFromDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toolset, err := NewSkillToolset(discovered, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	textResult, err := toolset.loadSkillResourceToolHandler(nil, loadSkillResourceArgs{SkillName: "lazy-skill", Path: "references/guide.md"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if textResult["encoding"] != "utf-8" || textResult["content"] != "guide" {
+		t.Fatalf("text result = %#v", textResult)
+	}
+	binaryResult, err := toolset.loadSkillResourceToolHandler(nil, loadSkillResourceArgs{SkillName: "lazy-skill", Path: "assets/template.bin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binaryResult["encoding"] != "base64" || binaryResult["content"] != base64.StdEncoding.EncodeToString(binary) {
+		t.Fatalf("binary result = %#v", binaryResult)
+	}
+}
+
+func TestLoadSkillResourceToolStableErrors(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "lazy-skill")
+	writeLazySkillFile(t, filepath.Join(skillDir, "SKILL.md"), "---\nname: lazy-skill\ndescription: lazy resources\n---\ninstructions\n")
+	if err := os.MkdirAll(filepath.Join(skillDir, "assets", "directory"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	largePath := filepath.Join(skillDir, "assets", "large.bin")
+	writeLazySkillFile(t, largePath, "x")
+	if err := os.Truncate(largePath, MAX_SKILL_PAYLOAD_BYTES+1); err != nil {
+		t.Fatal(err)
+	}
+	discovered, err := skills.DiscoverSkillsFromDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	toolset, err := NewSkillToolset(discovered, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		path string
+		code string
+	}{
+		{path: "../outside", code: "INVALID_RESOURCE_PATH"},
+		{path: "assets/missing", code: "RESOURCE_NOT_FOUND"},
+		{path: "assets/directory", code: "INVALID_RESOURCE_TYPE"},
+		{path: "assets/large.bin", code: "RESOURCE_TOO_LARGE"},
+	} {
+		result, callErr := toolset.loadSkillResourceToolHandler(nil, loadSkillResourceArgs{SkillName: "lazy-skill", Path: test.path})
+		if callErr != nil {
+			t.Fatalf("path %q call error = %v", test.path, callErr)
+		}
+		if result["error_code"] != test.code {
+			t.Errorf("path %q error code = %v, want %s", test.path, result["error_code"], test.code)
+		}
+		if strings.Contains(result["error"].(string), root) {
+			t.Errorf("path %q exposed root in error %q", test.path, result["error"])
+		}
+	}
+
+	canceled := resourceReadError(loadSkillResourceArgs{SkillName: "lazy-skill", Path: "assets/data"}, context.Canceled)
+	if canceled["error_code"] != "RESOURCE_READ_CANCELED" {
+		t.Fatalf("canceled error = %#v", canceled)
+	}
+}
+
+func TestNewSkillToolsetRejectsNilAndDuplicateSkills(t *testing.T) {
+	if _, err := NewSkillToolset([]*skills.Skill{nil}, nil); err == nil {
+		t.Fatal("NewSkillToolset(nil skill) error = nil")
+	}
+	first := &skills.Skill{Frontmatter: &skills.Frontmatter{Name: "duplicate", Description: "first"}}
+	second := &skills.Skill{Frontmatter: &skills.Frontmatter{Name: "duplicate", Description: "second"}}
+	if _, err := NewSkillToolset([]*skills.Skill{first, second}, nil); err == nil {
+		t.Fatal("NewSkillToolset(duplicate skills) error = nil")
+	}
+}
+
+func writeLazySkillFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tool/skilltool/skill_toolset.go
+++ b/tool/skilltool/skill_toolset.go
@@ -15,11 +15,18 @@
 package skilltool
 
 import (
+	"bytes"
+	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"mime"
+	"net/http"
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/volcengine/veadk-go/code_executors"
 	"github.com/volcengine/veadk-go/log"
@@ -31,7 +38,7 @@ import (
 	"google.golang.org/genai"
 )
 
-const MAX_SKILL_PAYLOAD_BYTES = 16 * 1024 * 1024 // 16 MB
+const MAX_SKILL_PAYLOAD_BYTES = skills.DefaultMaxResourceBytes
 const DEFAULT_SKILL_SYSTEM_INSTRUCTION = "" +
 	"You can use specialized 'skills' to help you with complex tasks. You MUST use the skill tools to interact with these skills.\n\n" +
 	"Skills are folders of instructions and resources that extend your capabilities for specialized tasks. Each skill folder contains:\n" +
@@ -42,7 +49,7 @@ const DEFAULT_SKILL_SYSTEM_INSTRUCTION = "" +
 	"This is very important:\n\n" +
 	"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
 	"2. Once you have read the instructions, follow them exactly as documented before replying to the user. For example, If the instruction lists multiple steps, please make sure you complete all of them in order.\n" +
-	"3. The `load_skill_resource` tool is for viewing files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`). Do NOT use other tools to access these files.\n" +
+	"3. The `load_skill_resource` tool is for viewing relative files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`, or files referenced beside SKILL.md). Do NOT use other tools to access these files.\n" +
 	"4. Use `run_skill_script` to run scripts from a skill's `scripts/` directory. Use `load_skill_resource` to view script content first if needed.\n"
 
 // SkillToolset A toolset for managing and interacting with agent skills.
@@ -55,6 +62,9 @@ type SkillToolset struct {
 func NewSkillToolset(skillList []*skills.Skill, codeExecutor code_executors.CodeExecutor) (*SkillToolset, error) {
 	m := make(map[string]*skills.Skill, len(skillList))
 	for _, s := range skillList {
+		if s == nil || s.Frontmatter == nil {
+			return nil, fmt.Errorf("skill and frontmatter are required")
+		}
 		if _, dup := m[s.Name()]; dup {
 			return nil, fmt.Errorf("duplicate skill name '%s'", s.Name())
 		}
@@ -192,44 +202,59 @@ func (s *SkillToolset) loadSkillResourceToolHandler(ctx tool.Context, args loadS
 	if !ok {
 		return map[string]any{"error": fmt.Sprintf("Skill '%s' not found.", args.SkillName), "error_code": "SKILL_NOT_FOUND"}, nil
 	}
-	var content string
-	var found bool
-	if strings.HasPrefix(args.Path, "references/") {
-		name := strings.TrimPrefix(args.Path, "references/")
-		content, found = sk.Resources.GetReference(name)
-	} else if strings.HasPrefix(args.Path, "assets/") {
-		name := strings.TrimPrefix(args.Path, "assets/")
-		content, found = sk.Resources.GetAsset(name)
-	} else if strings.HasPrefix(args.Path, "scripts/") {
-		name := strings.TrimPrefix(args.Path, "scripts/")
-		scr, ok2 := sk.Resources.GetScript(name)
-		if ok2 && scr != nil {
-			content, found = scr.Src, true
-		}
-	} else {
-		return map[string]any{
-			"error":      "Path must start with 'references/', 'assets/', or 'scripts/'.",
-			"error_code": "INVALID_RESOURCE_PATH",
-		}, nil
+	readContext := context.Background()
+	if ctx != nil {
+		readContext = ctx
 	}
-	if !found {
-		return map[string]any{
-			"error":      fmt.Sprintf("Resource '%s' not found in skill '%s'.", args.Path, args.SkillName),
-			"error_code": "RESOURCE_NOT_FOUND",
-		}, nil
+	data, err := sk.ReadResourceContext(readContext, args.Path, MAX_SKILL_PAYLOAD_BYTES)
+	if err != nil {
+		return resourceReadError(args, err), nil
 	}
-	return map[string]any{
+
+	mediaType := mime.TypeByExtension(filepath.Ext(args.Path))
+	if mediaType == "" {
+		mediaType = http.DetectContentType(data)
+	}
+	result := map[string]any{
 		"skill_name": sk.Name(),
 		"path":       args.Path,
-		"content":    content,
-	}, nil
+		"media_type": mediaType,
+	}
+	if utf8.Valid(data) && !bytes.ContainsRune(data, '\x00') {
+		result["content"] = string(data)
+		result["encoding"] = "utf-8"
+	} else {
+		result["content"] = base64.StdEncoding.EncodeToString(data)
+		result["encoding"] = "base64"
+	}
+	return result, nil
+}
+
+func resourceReadError(args loadSkillResourceArgs, err error) map[string]any {
+	code := "RESOURCE_READ_ERROR"
+	message := fmt.Sprintf("Resource '%s' in skill '%s' could not be read.", args.Path, args.SkillName)
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		code = "RESOURCE_READ_CANCELED"
+	case errors.Is(err, skills.ErrInvalidResourcePath):
+		code = "INVALID_RESOURCE_PATH"
+	case errors.Is(err, skills.ErrResourceNotFound):
+		code = "RESOURCE_NOT_FOUND"
+	case errors.Is(err, skills.ErrResourceTooLarge):
+		code = "RESOURCE_TOO_LARGE"
+	case errors.Is(err, skills.ErrResourceNotRegular):
+		code = "INVALID_RESOURCE_TYPE"
+	case errors.Is(err, skills.ErrResourceChanged):
+		code = "RESOURCE_CHANGED"
+	}
+	return map[string]any{"error": message, "error_code": code}
 }
 
 // loadSkillResourceTool Tool to load resources (references, assets, or scripts) from a skill."""
 func (s *SkillToolset) loadSkillResourceTool() tool.Tool {
 	t, _ := functiontool.New(functiontool.Config{
 		Name:        "load_skill_resource",
-		Description: "Loads a resource file (from references/, assets/, or scripts/) from within a skill.",
+		Description: "Loads a relative resource file from within a skill.",
 	}, s.loadSkillResourceToolHandler)
 	return t
 }
@@ -256,6 +281,9 @@ func (s *SkillToolset) runSkillScriptToolHandler(ctx tool.Context, args runSkill
 		name = strings.TrimPrefix(args.ScriptPath, "scripts/")
 	}
 
+	if sk.Resources == nil {
+		return map[string]any{"error": fmt.Sprintf("Script '%s' is not loaded for skill '%s'.", args.ScriptPath, args.SkillName), "error_code": "SCRIPT_NOT_LOADED"}, nil
+	}
 	if scr, ok := sk.Resources.GetScript(name); !ok || scr == nil {
 		return map[string]any{"error": fmt.Sprintf("Script '%s' not found in skill '%s'.", args.ScriptPath, args.SkillName), "error_code": "SCRIPT_NOT_FOUND"}, nil
 	}

--- a/tool/skilltool/skill_toolset.go
+++ b/tool/skilltool/skill_toolset.go
@@ -39,7 +39,7 @@ import (
 )
 
 const MAX_SKILL_PAYLOAD_BYTES = skills.DefaultMaxResourceBytes
-const DEFAULT_SKILL_SYSTEM_INSTRUCTION = "" +
+const defaultReadOnlySkillSystemInstruction = "" +
 	"You can use specialized 'skills' to help you with complex tasks. You MUST use the skill tools to interact with these skills.\n\n" +
 	"Skills are folders of instructions and resources that extend your capabilities for specialized tasks. Each skill folder contains:\n" +
 	"- **SKILL.md** (required): The main instruction file with skill metadata and detailed markdown instructions.\n" +
@@ -49,7 +49,9 @@ const DEFAULT_SKILL_SYSTEM_INSTRUCTION = "" +
 	"This is very important:\n\n" +
 	"1. If a skill seems relevant to the current user query, you MUST use the `load_skill` tool with `name=\"<SKILL_NAME>\"` to read its full instructions before proceeding.\n" +
 	"2. Once you have read the instructions, follow them exactly as documented before replying to the user. For example, If the instruction lists multiple steps, please make sure you complete all of them in order.\n" +
-	"3. The `load_skill_resource` tool is for viewing relative files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`, or files referenced beside SKILL.md). Do NOT use other tools to access these files.\n" +
+	"3. The `load_skill_resource` tool is for viewing relative files within a skill's directory (e.g., `references/*`, `assets/*`, `scripts/*`, or files referenced beside SKILL.md). Do NOT use other tools to access these files.\n"
+
+const DEFAULT_SKILL_SYSTEM_INSTRUCTION = defaultReadOnlySkillSystemInstruction +
 	"4. Use `run_skill_script` to run scripts from a skill's `scripts/` directory. Use `load_skill_resource` to view script content first if needed.\n"
 
 // SkillToolset A toolset for managing and interacting with agent skills.
@@ -57,9 +59,21 @@ type SkillToolset struct {
 	skills       map[string]*skills.Skill
 	tools        []tool.Tool
 	codeExecutor code_executors.CodeExecutor
+	instruction  string
 }
 
 func NewSkillToolset(skillList []*skills.Skill, codeExecutor code_executors.CodeExecutor) (*SkillToolset, error) {
+	return newSkillToolset(skillList, codeExecutor, true)
+}
+
+// NewReadOnlySkillToolset creates a toolset for discovered local skills. It
+// exposes metadata and lazy resource reads, but deliberately does not expose
+// script execution.
+func NewReadOnlySkillToolset(skillList []*skills.Skill) (*SkillToolset, error) {
+	return newSkillToolset(skillList, nil, false)
+}
+
+func newSkillToolset(skillList []*skills.Skill, codeExecutor code_executors.CodeExecutor, includeScriptTool bool) (*SkillToolset, error) {
 	m := make(map[string]*skills.Skill, len(skillList))
 	for _, s := range skillList {
 		if s == nil || s.Frontmatter == nil {
@@ -73,12 +87,16 @@ func NewSkillToolset(skillList []*skills.Skill, codeExecutor code_executors.Code
 	st := &SkillToolset{
 		skills:       m,
 		codeExecutor: codeExecutor,
+		instruction:  defaultReadOnlySkillSystemInstruction,
 	}
 	st.tools = []tool.Tool{
 		st.listSkillsTool(),
 		st.loadSkillTool(),
 		st.loadSkillResourceTool(),
-		st.runSkillScriptTool(),
+	}
+	if includeScriptTool {
+		st.tools = append(st.tools, st.runSkillScriptTool())
+		st.instruction = DEFAULT_SKILL_SYSTEM_INSTRUCTION
 	}
 	return st, nil
 }
@@ -98,7 +116,7 @@ func (s *SkillToolset) Tools(ctx agent.ReadonlyContext) ([]tool.Tool, error) {
 func (s *SkillToolset) ProcessRequest(ctx tool.Context, req *model.LLMRequest) error {
 	skillList := s.listSkills()
 	skillXML := skills.FormatSkillsAsXML(skillList)
-	instruction := []string{DEFAULT_SKILL_SYSTEM_INSTRUCTION, skillXML}
+	instruction := []string{s.instruction, skillXML}
 	if req.Config.SystemInstruction == nil {
 		req.Config.SystemInstruction = &genai.Content{
 			Parts: []*genai.Part{


### PR DESCRIPTION
## Summary

- add stable metadata-first discovery for immediate child Skill directories
- let `llmagent.Config{Skills: []string{root}}` discover a whole local Skills root and attach one read-only Skill toolset
- provide skip-invalid and strict policies with structured diagnostic callbacks
- lazily read text and binary resources with a 16 MiB limit and request cancellation
- use Go rooted filesystem access to block absolute paths, traversal, symlink escapes, special files, and replacement races
- return stable skill-tool error codes without exposing filesystem internals
- update the main Skills example to take one root through `VEADK_SKILLS_DIR`

## Compatibility and scope

- `Skills` entries use the veadk-python local-mode meaning: each entry is a parent directory whose immediate children are individual Skills
- new discovery follows the Agent Skills `SKILL.md` filename and parent-directory naming contract
- existing `LoadSkillFromDir` retains legacy lowercase `skill.md` support and eager loading behavior
- disk resources may be any relative regular file below the Skill root, including references placed beside `SKILL.md` by the real docx/pdf/pptx Skills
- Agent-level auto-wiring is read-only in this PR and does not advertise `run_skill_script`; guarded workspace and script execution remain intentionally scoped to PR 5
- this branch is based directly on upstream/main and does not depend on PR #83

## Contract coverage

- Agent construction from one or more Skills roots, blank entries, duplicate names across roots, strict failure without partial toolset mutation, and read-only tool exposure
- stable ordering, direct-child-only scanning, linked outer root, malformed YAML, missing/mis-cased `SKILL.md`, name mismatch, oversized document, unreadable file, cancellation, strict/skip behavior, and duplicate toolset names
- lazy UTF-8/base64 resources, exact/oversized limits, missing files, directories/FIFOs, absolute/Windows/traversal paths, safe and escaping symlinks, and concurrent symlink replacement
- real Sandbox Skill root discovers docx, pdf, pptx, skill-creator, tos-file-access, and xlsx; a required resource was read and hashed without printing contents
- the real `examples/skills` server started with the configured model, handled `/invoke`, reported all six Skills, loaded the docx instructions, returned HTTP 200, and shut down gracefully

## Validation

- `go test -count=30 ./agent/llmagent ./skills ./tool/skilltool`
- `go test -race -count=5 -shuffle=on ./agent/llmagent ./skills ./tool/skilltool`
- `go test ./examples/...`
- `go vet ./agent/llmagent ./skills ./tool/skilltool ./examples/skills ./examples/skills/discovery`
- golangci-lint v2.13.2: 0 issues for changed packages
- all non-config packages pass `go test` with required gcflags and `go vet`
- `go build -mod=readonly ./...`
- `go mod tidy -diff`

Specification reference: https://agentskills.io/specification